### PR TITLE
tagprのワークフローからciジョブを削除

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -19,17 +19,6 @@ jobs:
         name: Run tagpr
         uses: Songmu/tagpr@v1
 
-  ci:
-    needs: tagpr
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@v3
-      - name: Trigger ci action
-        uses: ./.github/actions/ci
-
   release:
   # 現在はまだ本番環境がないので、動作確認用のサンプルジョブを実行
     needs: tagpr


### PR DESCRIPTION
## Issue
- https://github.com/peno022/kpi-tree-generator/issues/57
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要
- tagprのあとに直接ciを動かすのをやめる
  - Checksが有効にならなかったため
  - 別な方法を検討し、別PRで修正する

## 動作確認方法
割愛
<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot
割愛
