### PR TITLE
tagprで利用するトークンを変更（後続のリリースジョブ）

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT }}
       - name: Trigger release action
         uses: ./.github/actions/release
 

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -27,7 +27,7 @@ jobs:
     if: needs.tagpr.outputs.tagpr-tag != ''
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -10,10 +10,12 @@ jobs:
     outputs:
       tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - id: run-tagpr
         name: Run tagpr


### PR DESCRIPTION
## Issue
- https://github.com/peno022/kpi-tree-generator/issues/57
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要
- tagprのジョブと、tagprのジョブ完了時にCIをトリガーするところまでは変更後のトークンで成功したので、後続のリリース用ジョブのトークンも変更

## 動作確認方法
リリースPRをマージしてtagprによってタグが打たれたら、リリースジョブが動いてほしい
<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot
割愛

### 変更前

### 変更後
