### PR TITLE
actions/setup-nodeを使う

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,9 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Node.js
-        run: |
-          # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-          curl -sL https://deb.nodesource.com/setup_19.x | bash -
-          apt-get install -y nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: '19.4'
 
       - name: Install Bundler
         run: gem install bundler --no-document -v $(grep "BUNDLED WITH" -1 Gemfile.lock | tail -n 1)


### PR DESCRIPTION
## Issue
- https://github.com/peno022/kpi-tree-generator/issues/89
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要
- ciのNodeをsetup-nodeアクションを使うように変更した
- 利用しているNodeバージョンの問題でNode.jsのキャッシュはできなかったが、Nodeのインストールコマンドを直接実行するよりは速くなったので、setup-nodeを利用することにした
  - [actions/setup-nodeでNode.jsがキャッシュされていない - ぺのめも](https://peno022.hatenablog.com/entry/nodejs-not-cached-in-setup-node)

## 動作確認方法
- ciが通るのを確認
<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot
割愛

### 変更前

### 変更後
