### PR TITLE
postgresのバージョンを15.1に固定

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,12 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | b
   && source ~/.bashrc \
   && nvm install 19.4 \
   && nvm use 19.4
+
+# Install PostgreSQL
+RUN apt-get update
+RUN apt-get -y install curl gnupg2 ca-certificates
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update
+RUN apt-get -y install postgresql-15
+RUN apt-get -y install postgresql-client

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: postgres:latest
-    restart: unless-stopped
+    image: postgres:15.1
+    # restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./create-db-user.sql:/docker-entrypoint-initdb.d/create-db-user.sql


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/91

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- VSCode Dev Container で利用するposgresのバージョンが`latest`になっていたので、docker-composeを修正して`15.1`で固定
  - DBの再起動オプションはいったん不要そうなのでコメントアウト
- アプリ開発用のコンテナにpostgresをインストールするようDockerfileを修正
  - 参考にしたもの
    - [PostgreSQL: Linux downloads (Debian)](https://www.postgresql.org/download/linux/debian/)
    - [Apt - PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt)

## 動作確認方法

- VSCode Dev Containerを起動し、`psql -h db -U postgres -d ktg_development` で`ktg_development`のDBに接続できることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛

### 変更前

### 変更後