### PR TITLE
CIにPostgreSQL接続を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,27 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15.1
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+          
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     container:
       image: ruby:3.1.3
       env:
         RAILS_ENV: test
+        DATABASE_HOST: postgres
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
@@ -54,6 +71,9 @@ jobs:
 
       - name: Run rubocop
         run: bundle exec rubocop
+
+      - name: DB setup
+        run: bundle exec rails db:setup
 
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
+      db:
         image: postgres:15.1
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres
           POSTGRES_PASSWORD: postgres
-          
+
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -27,7 +27,7 @@ jobs:
       image: ruby:3.1.3
       env:
         RAILS_ENV: test
-        DATABASE_HOST: postgres
+        DATABASE_HOST: db
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
## Issue
- https://github.com/peno022/kpi-tree-generator/issues/53
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

## 動作確認方法

PR作成・更新時に動くCI上で

- `bundle exec rails db:setup`が実行できる
- 下記のエラーが出なくなる

```log
An error occurred while loading ./spec/helpers/home_helper_spec.rb.
Failure/Error: ActiveRecord::Migration.maintain_test_schema!

ActiveRecord::ConnectionNotEstablished:
  could not translate host name "db" to address: Temporary failure in name resolution
# ./spec/rails_helper.rb:30:in `<top (required)>'
# ./spec/helpers/home_helper_spec.rb:3:in `require'
# ./spec/helpers/home_helper_spec.rb:3:in `<top (required)>'
# ------------------
# --- Caused by: ---
# PG::ConnectionBad:
#   could not translate host name "db" to address: Temporary failure in name resolution
#   ./spec/rails_helper.rb:30:in `<top (required)>'
```

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛

### 変更前

### 変更後
