### PR TITLE
RSpec の System Spec が headless_chromeで動くようにする

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,9 @@ services:
     command: sleep infinity
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
+
+    networks:
+      ktg-net:
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -22,6 +24,8 @@ services:
     image: selenium/standalone-chrome-debug
     ports:
       - "4444:4444"
+    networks:
+      ktg-net:
   
   db:
     image: postgres:15.1
@@ -48,6 +52,11 @@ services:
 
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
+    networks:
+      ktg-net:
+
+networks:
+  ktg-net:
 
 volumes:
   postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,10 +20,11 @@ services:
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
+    environment:
+      - SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub
+
   selenium_chrome:
     image: selenium/standalone-chrome-debug
-    ports:
-      - "4444:4444"
     networks:
       ktg-net:
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       env:
         RAILS_ENV: test
         DATABASE_HOST: db
-      environment:
-        - SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub
+        SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
 
       selenium_chrome:
         image: selenium/standalone-chrome-debug
-        ports:
-          - "4444:4444"
 
     container:
       image: ruby:3.1.3
       env:
         RAILS_ENV: test
         DATABASE_HOST: db
+      environment:
+        - SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         RAILS_ENV: test
         DATABASE_HOST: db
         SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
+      options:
+        name: app
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
         RAILS_ENV: test
         DATABASE_HOST: db
         SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
-      options:
-        name: app
+      options: --name app
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,4 @@ group :test do
   gem 'capybara'
   gem 'launchy'
   gem 'selenium-webdriver'
-  gem 'webdrivers'
-  gem 'webdrivers', require: !ENV['SELENIUM_DRIVER_URL']
 end

--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,5 @@ group :test do
   gem 'launchy'
   gem 'selenium-webdriver'
   gem 'webdrivers'
+  gem 'webdrivers', require: !ENV['SELENIUM_DRIVER_URL']
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,10 +254,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -293,7 +289,6 @@ DEPENDENCIES
   slim-rails
   tzinfo-data
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.1.3p185

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,9 +1,41 @@
 # frozen_string_literal: true
 
+# Capybara.register_driver :chrome_headless do |app|
+#   options = ::Selenium::WebDriver::Chrome::Options.new
+
+#   # options.add_argument('--headless')
+#   options.add_argument('--no-sandbox')
+#   options.add_argument('--disable-dev-shm-usage')
+#   # options.add_argument('--window-size=1400,1400')
+
+#   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+# end
+
+# Capybara.javascript_driver = :chrome_headless
+
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
+
+  # config.before(:each, js: true, type: :system) do
+  #   driven_by :selenium_chrome_headless
+  # end
+  # config.before(:each, js: true, type: :system) do
+  #   driven_by :chrome_headless
+  # end
+
+  # https://qiita.com/suketa/items/d783ac61c2a3e4c16ad4#docker-composeyml-%E3%81%AE%E7%B7%A8%E9%9B%86
+  # config.before(:each, js: true, type: :system) do
+  #   driven_by :selenium, using: :chrome, options: {
+  #     browser: :remote,
+  #     url: ENV.fetch('SELENIUM_DRIVER_URL'),
+  #     desired_capabilities: :chrome
+  #   }
+  #   Capybara.server_host = 'app'
+  #   Capybara.app_host='http://app'
+  # end
 
   config.before(:each, js: true, type: :system) do
     driven_by :selenium, using: :headless_chrome, options: {
@@ -11,6 +43,5 @@ RSpec.configure do |config|
       url: ENV.fetch('SELENIUM_DRIVER_URL'),
     }
     Capybara.server_host = 'app'
-    Capybara.app_host='http://app'
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,7 +8,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium, using: :headless_chrome, options: {
       browser: :remote,
-      url: ENV.fetch('SELENIUM_DRIVER_URL'),
+      url: ENV.fetch('SELENIUM_DRIVER_URL')
     }
     Capybara.server_host = 'app'
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,6 +6,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, js: true, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium, using: :headless_chrome, options: {
+      browser: :remote,
+      url: ENV.fetch('SELENIUM_DRIVER_URL'),
+    }
+    Capybara.server_host = 'app'
+    Capybara.app_host='http://app'
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,41 +1,9 @@
 # frozen_string_literal: true
 
-# Capybara.register_driver :chrome_headless do |app|
-#   options = ::Selenium::WebDriver::Chrome::Options.new
-
-#   # options.add_argument('--headless')
-#   options.add_argument('--no-sandbox')
-#   options.add_argument('--disable-dev-shm-usage')
-#   # options.add_argument('--window-size=1400,1400')
-
-#   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-# end
-
-# Capybara.javascript_driver = :chrome_headless
-
-
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
-
-  # config.before(:each, js: true, type: :system) do
-  #   driven_by :selenium_chrome_headless
-  # end
-  # config.before(:each, js: true, type: :system) do
-  #   driven_by :chrome_headless
-  # end
-
-  # https://qiita.com/suketa/items/d783ac61c2a3e4c16ad4#docker-composeyml-%E3%81%AE%E7%B7%A8%E9%9B%86
-  # config.before(:each, js: true, type: :system) do
-  #   driven_by :selenium, using: :chrome, options: {
-  #     browser: :remote,
-  #     url: ENV.fetch('SELENIUM_DRIVER_URL'),
-  #     desired_capabilities: :chrome
-  #   }
-  #   Capybara.server_host = 'app'
-  #   Capybara.app_host='http://app'
-  # end
 
   config.before(:each, js: true, type: :system) do
     driven_by :selenium, using: :headless_chrome, options: {

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before(:each, type: :system) do
-    driven_by :rack_test
-  end
+  # config.before(:each, type: :system) do
+  #   driven_by :rack_test
+  # end
 
-  config.before(:each, js: true, type: :system) do
+  config.before(:each, type: :system) do
     driven_by :selenium, using: :headless_chrome, options: {
       browser: :remote,
       url: ENV.fetch('SELENIUM_DRIVER_URL'),


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/105

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- RSpec の System Spec が headless_chromeで動くようにしました。
  - https://github.com/peno022/kpi-tree-generator/pull/101 のPRでの`spec/support/capybara.rb`の修正内容は誤りだったため修正しました。そもそも`js: true`の設定をしたspecが無い状態だったため、誤った設定の箇所を通っておらず、エラーにもなっていなかったという状態でした。
- デフォルトのrack_testではなくheadless_chromeのドライバで実行することで、テスト失敗時には対象画面があればスクリーンショットが保存されるようになりました。（rack_test だとHTMLのみが保存される）

## 動作確認方法
- VSCode remote containerで開発環境を起動
- `bundle exec rspec`を実行して、テストが全て通ることを確認する
-` bin/dev`を実行してhttp://127.0.0.1:3001/ にアクセスし、アプリケーションが立ち上がることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛

### 変更前

### 変更後
