### PR TITLE
ツリーの初期表示位置を調整

### DIFF
--- a/app/javascript/components/tree.tsx
+++ b/app/javascript/components/tree.tsx
@@ -51,15 +51,17 @@ const EditTree = () => {
   };
   return (
     <>
-      <div id="treeWrapper" style={{ width: "50em", height: "50em" }}>
+      <div className="container flex-grow" id="treeWrapper">
         <Tree
           key={treeKey}
+          translate={{ x: 350, y: 20 }}
           data={nodeDatum}
           pathFunc="diagonal"
           orientation="vertical"
           renderCustomNodeElement={CustomNode}
           onNodeClick={handleClick}
           separation={{ siblings: 2, nonSiblings: 2 }}
+          zoom={0.7}
         />
       </div>
     </>

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,5 +1,6 @@
-nav.navbar.bg-base-100.flex.justify-center.border-b-2.border-base-300
-  h1.text-xl.font-bold
-    | #{@tree.name}
-.container.mx-10
-  #tree.my-5 data-tree-id=@tree.id
+.flex.flex-col.min-h-screen
+  nav.navbar.bg-base-100.flex.justify-center.border-b-2.border-base-300
+    h1.text-xl.font-bold
+      | #{@tree.name}
+  .container.flex.grow#tree.w-full.mx-auto data-tree-id=@tree.id
+  

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,8 +1,5 @@
-nav.navbar.bg-base-100
-  .flex-1
-    a.btn.btn-ghost.normal-case.text-xl
-      |KPIツリーメーカー
+nav.navbar.bg-base-100.flex.justify-center.border-b-2.border-base-300
+  h1.text-xl.font-bold
+    | #{@tree.name}
 .container.mx-10
-  h1.text-xl
-    | ツリー1の編集画面（仮）
   #tree.my-5 data-tree-id=@tree.id

--- a/spec/system/trees_spec.rb
+++ b/spec/system/trees_spec.rb
@@ -2,49 +2,49 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Tree pages', js: true,
-                             pending: '初期表示時に画面枠外に出てしまって見えないノードのクリックや存在確認ができないため。
-   issue#152で初期表示位置の修正時にテストが通るようにする' do
+RSpec.describe 'Tree pages', js: true do
   it('treeの詳細画面に、treeの図が表示されている') do
     tree1 = create(:tree)
-    nodes = create_list(:node, 3, tree: tree1)
-    nodes[1].name = '子1'
-    nodes[2].name = '子2'
-    nodes[0].children = [nodes[1], nodes[2]]
+    nodes1 = create_list(:node, 3, tree: tree1)
+    nodes1[1].name = '子1'
+    nodes1[2].name = '子2'
+    nodes1[0].children = [nodes1[1], nodes1[2]]
     visit edit_tree_path(tree1)
-    expect(page).to have_css('g > text', text: nodes[0].name)
-    expect(page).to have_css('g > text', text: nodes[1].name)
-    expect(page).to have_css('g > text', text: nodes[2].name)
+    expect(page).to have_css('g > text', text: nodes1[0].name)
+    expect(page).to have_css('g > text', text: nodes1[1].name)
+    expect(page).to have_css('g > text', text: nodes1[2].name)
     expect(page).to have_css('svg > g > path.rd3t-link', count: 2)
   end
 
   it('treeの子ノードをクリックすると、兄弟ノードの色が変わる') do
-    tree1 = create(:tree)
-    nodes = create_list(:node, 3, tree: tree1)
-    nodes[1].name = '子1'
-    nodes[2].name = '子2'
-    nodes[0].children = [nodes[1], nodes[2]]
+    tree2 = create(:tree)
+    nodes2 = create_list(:node, 3, tree: tree2)
+    nodes2[1].name = '子1'
+    nodes2[2].name = '子2'
+    nodes2[0].children = [nodes2[1], nodes2[2]]
 
-    visit edit_tree_path(tree1)
-    target_node = find('g > text', text: '子1').ancestor('g')
+    visit edit_tree_path(tree2)
+    target_node_before = find('g > text', text: '子1').ancestor('g.rd3t-leaf-node')
     sibling_node_before = find('g > text', text: '子2').ancestor('g.rd3t-leaf-node')
-    expect(target_node.child('rect')[:style]).to include('fill: ghostwhite')
+    expect(target_node_before.find('rect')[:style]).to include('fill: ghostwhite')
     expect(sibling_node_before.find('rect')[:style]).to include('fill: ghostwhite')
-    sibling_node_before.click
-    expect(target_node.child('rect')[:style]).to include('fill: moccasin')
+    target_node_before.click
+    target_node_after = find('g > text', text: '子1').ancestor('g.rd3t-leaf-node')
+    expect(target_node_after.find('rect')[:style]).to include('fill: moccasin')
     sibling_node_after = find('g > text', text: '子2').ancestor('g.rd3t-leaf-node')
     expect(sibling_node_after.find('rect')[:style]).to include('fill: moccasin')
   end
 
   it('treeのルートノードをクリックすると、ルートノードの色が変わる') do
-    tree1 = create(:tree)
-    create(:node, tree: tree1, name: 'ルートノード')
-    visit edit_tree_path(tree1)
+    tree3 = create(:tree)
+    create(:node, name: 'ルート', tree: tree3)
 
-    target_node_before = find('svg > g > g > g > text', text: 'ルートノード').ancestor('g.rd3t-leaf-node')
+    visit edit_tree_path(tree3)
+
+    target_node_before = find('g > text', text: 'ルート').ancestor('g:not([class])')
     expect(target_node_before.find('rect')[:style]).to include('fill: ghostwhite')
     target_node_before.click
-    target_node_after = find('svg > g > g > g > text', text: 'ルートノード').ancestor('g.rd3t-leaf-node')
+    target_node_after = find('g > text', text: 'ルート').ancestor('g:not([class])')
     expect(target_node_after.find('rect')[:style]).to include('fill: moccasin')
   end
 end


### PR DESCRIPTION
## Issue

close #152 

- https://github.com/peno022/kpi-tree-generator/issues/152
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリーの初期表示位置が、デフォルト状態だとルートノード中心が表示エリア左上に来てしまうので修正した
  - 今後のコンポーネントの追加によりレイアウト調整が入っていくと思うので、初期表示の座標をTreeコンポーネントに定数で指定している。
- pendingにしていたテストを修正
  - ノードが見切れてしまうことでテストが実行できずにpendingにしていたtrees_spec.rbがパスするように修正した。


## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. `bundle exec rspec`でRailsのテストがパスすることを確認
3. `yarn jest`でTypeScriptモジュールのテストがパスすることを確認
4. `bin/dev`を実行してから、http://127.0.0.1:3001/trees/1/edit にアクセスし、アプリケーションが問題なく立ち上がること・ツリーのルートノードがエリア左上を基準に{x: 350, y:20}の位置で表示されるようになっていることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

<img width="776" alt="スクリーンショット 2023-04-18 10 40 36" src="https://user-images.githubusercontent.com/40317050/232647652-bee15c6c-1ab2-4ac7-88ba-d23203e2b509.png">

### 変更後

<img width="924" alt="スクリーンショット 2023-04-18 10 40 18" src="https://user-images.githubusercontent.com/40317050/232647655-dac61af2-f42f-4c5a-ad6d-812626d32c34.png">
