### PR TITLE
ツリー編集画面のヘッダーパーツを追加

### DIFF
--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,6 +1,7 @@
 .flex.flex-col.min-h-screen
   nav.navbar.bg-base-100.flex.items-center.border-b-2.border-base-300
-    a.btn.btn-ghost
+    / TODO: ログインしていない場合はLPに、ログインしている場合はツリー一覧画面に遷移する
+    = link_to trees_path, class: 'btn btn-ghost' do
       p.mx-1
         i.fa.fa-lg.fa-angle-left[aria-hidden="true"]
         p.text-lg
@@ -8,14 +9,10 @@
     .dropdown.dropdown-bottom
       label.btn.btn-ghost.text-lg.rounded-btn[tabindex="0"]
         | ファイル
-      ul.menu.dropdown-content.p-2.shadow.bg-base-100\
-      .rounded-box.w-52.mt-4[tabindex="0"]
+      ul.menu.dropdown-content.p-2.shadow.bg-base-100.rounded-box.w-52.mt-4[tabindex="0"]
         li
           a
             | 保存
-        li
-          a
-            | ダウンロード
     .flex-grow.flex.justify-center
       h1.text-xl.font-bold
         | #{@tree.name}

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -2,5 +2,7 @@
   nav.navbar.bg-base-100.flex.justify-center.border-b-2.border-base-300
     h1.text-xl.font-bold
       | #{@tree.name}
+    a.btn.btn-ghost
+      i.fa.fa-pencil.mx-1[aria-hidden="true"]
   .container.flex.grow#tree.w-full.mx-auto data-tree-id=@tree.id
   

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,8 +1,29 @@
 .flex.flex-col.min-h-screen
-  nav.navbar.bg-base-100.flex.justify-center.border-b-2.border-base-300
-    h1.text-xl.font-bold
-      | #{@tree.name}
+  nav.navbar.bg-base-100.flex.items-center.border-b-2.border-base-300
     a.btn.btn-ghost
-      i.fa.fa-pencil.mx-1[aria-hidden="true"]
+      p.mx-1
+        i.fa.fa-lg.fa-angle-left[aria-hidden="true"]
+        p.text-lg
+          | ホーム
+    .dropdown.dropdown-bottom
+      label.btn.btn-ghost.text-lg.rounded-btn[tabindex="0"]
+        | ファイル
+      ul.menu.dropdown-content.p-2.shadow.bg-base-100\
+      .rounded-box.w-52.mt-4[tabindex="0"]
+        li
+          a
+            | 保存
+        li
+          a
+            | ダウンロード
+    .flex-grow.flex.justify-center
+      h1.text-xl.font-bold
+        | #{@tree.name}
+      a.btn.btn-ghost
+        i.fa.fa-lg.fa-pencil.mx-1[aria-hidden="true"]
+    a.btn.btn-outline.mx-1
+      | 画像ダウンロード
+    / TODO: ログインしていない場合はアカウント作成ボタンを、ログインしている場合はアイコンを表示する
+    a.btn.btn-primary.mx-1
+      | アカウント作成
   .container.flex.grow#tree.w-full.mx-auto data-tree-id=@tree.id
-  


### PR DESCRIPTION
## Issue

close #108 

- https://github.com/peno022/kpi-tree-generator/issues/108
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリー編集画面のヘッダーに下記を追加
  - ホームボタン（ツリー一覧画面へ遷移、ログイン状態による分岐はなし）
  - ファイルドロップダウンボタン
  -  画像ダウンロードボタン
  - アカウント作成ボタン

 - パーツを追加したのみで、実際の機能はなし。ホームボタン以外はクリックしても何も起きない状態。
 - テスト未作成。各ボタンの機能実装時にテストを追加する。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. `bin/dev`を実行してから、http://127.0.0.1:3001/trees/1/edit にアクセスし、アプリケーションが問題なく立ち上がることを確認
3. ツリー編集画面のヘッダーに、上記要素が表示されていることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

<img width="1080" alt="スクリーンショット 2023-04-20 8 07 40" src="https://user-images.githubusercontent.com/40317050/233218514-3aee1ae0-1087-49b0-9035-13aba6822912.png">

### 変更後

<img width="1088" alt="スクリーンショット 2023-04-20 8 08 00" src="https://user-images.githubusercontent.com/40317050/233218509-6627c80f-7c51-4385-a8b8-312dd90c388f.png">