### PR TITLE
Install slim_lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   ci:
@@ -61,7 +61,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '19.4'
+          node-version: "19.4"
 
       - name: Install Bundler
         run: gem install bundler --no-document -v $(grep "BUNDLED WITH" -1 Gemfile.lock | tail -n 1)
@@ -87,11 +87,8 @@ jobs:
       - name: Build JavaScript
         run: bin/rails javascript:build
 
-      - name: Run rubocop
-        run: bundle exec rubocop
-
       - name: Run lint
-        run: npm run lint
+        run: bin/lint
 
       - name: Run jest
         run: yarn jest

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'slim_lint'
   gem 'web-console'
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,9 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
+    slim_lint (0.24.0)
+      rubocop (>= 1.0, < 2.0)
+      slim (>= 3.0, < 6.0)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.11)
@@ -287,6 +290,7 @@ DEPENDENCIES
   rubocop-rspec
   selenium-webdriver
   slim-rails
+  slim_lint
   tzinfo-data
   web-console
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,8 +7,8 @@ html
     = csrf_meta_tags
     = csp_meta_tag
 
-    = stylesheet_link_tag "application"
-    = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
+    = stylesheet_link_tag 'application'
+    = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
     script src="https://kit.fontawesome.com/48b449efbc.js" crossorigin="anonymous"
 
   body

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -26,15 +26,15 @@ nav.navbar.bg-base-100
             | ログインなしで試す
 
   footer.footer.footer-center.p-10.bg-base-100.text-base-content.rounded
-    div.grid.grid-flow-col.gap-4
+    .grid.grid-flow-col.gap-4
       = link_to '利用規約', terms_of_use_path, class: 'link link-hover'
       = link_to 'プライバシーポリシー', privacy_policy_path, class: 'link link-hover'
       = link_to 'https://github.com/peno022/kpi-tree-generator', class: 'link link-hover' do
         i.fa-brands.fa-github
       = link_to 'https://twitter.com/peno022', class: 'link link-hover' do
         i.fa-brands.fa-twitter
-    div.grid.grid-flow-col.gap-4
+    .grid.grid-flow-col.gap-4
       p
-        | Copyright 
-        i.fa.fa-copyright 
+        | Copyright
+        i.fa.fa-copyright.mx-1
         | 2023 - peno022

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bundle exec rubocop -a
+bundle exec slim-lint app/**/*.slim -c config/slim_lint.yml
+npm run lint

--- a/bin/lint
+++ b/bin/lint
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+echo '> bundle exec rubocop -a'
 bundle exec rubocop -a
+
+echo '> bundle exec slim-lint app/**/*.slim -c config/slim_lint.yml'
 bundle exec slim-lint app/**/*.slim -c config/slim_lint.yml
+
+echo '> npm run lint'
 npm run lint

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -1,0 +1,3 @@
+linters:
+  LineLength:
+    max: 250


### PR DESCRIPTION
## Issue

close #156 

- https://github.com/peno022/kpi-tree-generator/issues/156

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- slim_lintを導入した
  - gemのインストール
  - configの作成
  - bin/lintでlintコマンド（rubocop , slim-lint, prettier, eslint）の実行をまとめる
  - CIでのlintもbin/lintを実行するように修正
- 現時点で出ていたslim_lintの警告が解消するようにslimファイルを修正した

## 動作確認方法
1. VSCode Remote Containerで開発環境を起動
1. `bin/lint`でrubocop, slim-lint, prettier, eslintが実行されること、lintルールに反した状態にするとエラーやワーニングが出ることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛

### 変更前

### 変更後
