### PR TITLE
ノードデータの入力値を計算式の表示に反映し、ノードの値同士を計算できるようにする

### DIFF
--- a/app/javascript/components/tool/calculationArea/calculation.tsx
+++ b/app/javascript/components/tool/calculationArea/calculation.tsx
@@ -1,69 +1,75 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import NodeValue from "./node_value";
 import OperationSymbol from "./operation_symbol";
 import Fraction from "./fraction";
 import MessageBubble from "./message_bubble";
-import { Node, Layer } from "../../../types";
+import { Node } from "../../../types";
 
 type Props = {
   selectedNodes: Node[];
-  selectedLayer: Layer | undefined;
-  parentNode: Node | undefined;
+  operation: "add" | "multiply";
+  parentNode: Node;
 };
 
 const Calculation: React.FC<Props> = ({
   parentNode,
-  selectedLayer,
+  operation,
   selectedNodes,
 }) => {
-  if (!parentNode && selectedNodes.length === 1) {
-    const rootNode = selectedNodes[0];
-    return (
-      <NodeValue
-        name={rootNode.name}
-        value={rootNode.value}
-        displayUnit={getDisplayUnit(rootNode)}
-      />
+  const maxId = Math.max(...selectedNodes.map((node) => node.id));
+  const [calculationResult, setCalculationResult] = useState(0);
+
+  useEffect(() => {
+    let newResult = 0;
+    if (operation === "multiply") {
+      newResult = selectedNodes.reduce((acc, node) => {
+        return acc * getValueForCalculation(node);
+      }, 1);
+    } else if (operation === "add") {
+      newResult = selectedNodes.reduce((acc, node) => {
+        return acc + getValueForCalculation(node);
+      }, 0);
+    }
+    setCalculationResult(
+      getValueForDisplay(newResult, parentNode.value_format)
     );
-  } else if (parentNode && selectedNodes.length > 1) {
-    const maxId = Math.max(...selectedNodes.map((node) => node.id));
-    return (
-      <>
-        <div className="flex flex-row">
-          <NodeValue
-            name={parentNode.name}
-            value={parentNode.value}
-            displayUnit={getDisplayUnit(parentNode)}
-          />
-          <OperationSymbol operation="equal" />
-          {selectedNodes.map((node, index) => {
-            return (
-              <div key={index} className="flex flex-row">
-                <NodeValue
-                  name={node.name}
-                  value={node.value}
-                  displayUnit={getDisplayUnit(node)}
-                />
-                {!(node.id === maxId) && selectedLayer && (
-                  <OperationSymbol operation={selectedLayer.operation} />
-                )}
-              </div>
-            );
-          })}
-          <OperationSymbol operation="add" />
-          <Fraction label="端数" />
-        </div>
-        <MessageBubble
-          type="under"
-          diffValue={100}
-          parentValue={1000}
-          displayUnit="万円"
+  }, [selectedNodes, operation]);
+
+  return (
+    <>
+      <div className="flex flex-row">
+        <NodeValue
+          name={parentNode.name}
+          value={calculationResult}
+          displayUnit={getDisplayUnit(parentNode)}
         />
-      </>
-    );
-  } else {
-    return <div>ノードが正しく選択できていません。</div>;
-  }
+        <OperationSymbol operation="equal" />
+        {selectedNodes.map((node, index) => {
+          return (
+            <div key={index} className="flex flex-row">
+              <NodeValue
+                name={node.name}
+                value={node.value}
+                displayUnit={getDisplayUnit(node)}
+              />
+              {!(node.id === maxId) && (
+                <OperationSymbol operation={operation} />
+              )}
+            </div>
+          );
+        })}
+        <OperationSymbol operation="add" />
+        <Fraction label="端数" />
+      </div>
+      {parentNode.value !== calculationResult && (
+        <MessageBubble
+          diffValue={calculationResult - parentNode.value}
+          parentValue={parentNode.value}
+          displayUnit={getDisplayUnit(parentNode)}
+        />
+      )}
+    </>
+  );
 };
 
 function getDisplayUnit(node: Node) {
@@ -72,6 +78,39 @@ function getDisplayUnit(node: Node) {
     return unit;
   } else {
     return `${node.value_format}${unit}`;
+  }
+}
+
+function getValueForCalculation(node: Node) {
+  switch (node.value_format) {
+    case "なし":
+      return node.value;
+    case "%":
+      return node.value / 100;
+    case "千":
+      return node.value * 1000;
+    case "万":
+      return node.value * 10000;
+    default:
+      return node.value;
+  }
+}
+
+function getValueForDisplay(
+  value: number,
+  valueFormat: "なし" | "%" | "千" | "万"
+) {
+  switch (valueFormat) {
+    case "なし":
+      return value;
+    case "%":
+      return value * 100;
+    case "千":
+      return value / 1000;
+    case "万":
+      return value / 10000;
+    default:
+      return value;
   }
 }
 

--- a/app/javascript/components/tool/calculationArea/message_bubble.tsx
+++ b/app/javascript/components/tool/calculationArea/message_bubble.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 
 type Props = {
-  type: "over" | "under";
   diffValue: number;
   parentValue: number;
   displayUnit: string;
 };
 
 const MessageBubble: React.FC<Props> = ({
-  type,
   diffValue,
   parentValue,
   displayUnit,
@@ -17,9 +15,11 @@ const MessageBubble: React.FC<Props> = ({
     <div className="relative bg-base-200 rounded p-1 w-max mt-2.5">
       <div className="absolute top-0 left-2 w-0 h-0 border-l-8 border-r-8 border-b-8 border-t-0 border-transparent border-b-base-200 -translate-y-full"></div>
       <p className="text-error font-semibold">
-        {diffValue.toLocaleString()}
+        {diffValue > 0
+          ? diffValue.toLocaleString()
+          : (-diffValue).toLocaleString()}
         {displayUnit}
-        {type === "under" ? "不足" : "超過"}（親要素:
+        {diffValue > 0 ? "超過" : "不足"}（親要素:
         {parentValue.toLocaleString()}
         {displayUnit}）
       </p>

--- a/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
@@ -2,19 +2,40 @@ import React from "react";
 import NodeField from "./node_field";
 import { Node } from "../../../types";
 import { ToolMenu } from "../common/tool_menu";
-type Props = {
-  order: number;
+
+type NodeDetailProps = {
+  index: number;
   node: Node;
   isRoot: boolean;
+  handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
 };
 
-const NodeDetail: React.FC<Props> = ({ order, node, isRoot = false }) => {
+const NodeDetail: React.FC<NodeDetailProps> = ({
+  index,
+  node,
+  isRoot = false,
+  handleNodeInfoChange,
+}) => {
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    console.log("handleInputChange");
+    const name = e.target.name;
+    let value: string | number | boolean;
+    if (e.target instanceof HTMLInputElement) {
+      value = e.target.type === "checkbox" ? e.target.checked : e.target.value;
+    } else {
+      value = e.target.value;
+    }
+    const updatedNodeInfo = { ...node, [name]: value };
+    handleNodeInfoChange(index, updatedNodeInfo);
+  };
   return (
     <>
       <div className="border border-base-300 p-2 my-2">
         <div className="flex justify-between items-center mb-1.5">
           <div className="text-base font-semibold">
-            {isRoot ? "ルート要素" : `要素${order}`}
+            {isRoot ? "ルート要素" : `要素${index + 1}`}
           </div>
           {!isRoot && (
             <ToolMenu
@@ -30,21 +51,43 @@ const NodeDetail: React.FC<Props> = ({ order, node, isRoot = false }) => {
           )}
         </div>
         <div className="flex flex-row space-x-4 mb-1.5">
-          <NodeField type="text" label="名前" value={node.name} />
-          <NodeField type="text" label="単位" value={node.unit} />
+          <NodeField
+            type="text"
+            name="name"
+            label="名前"
+            value={node.name}
+            onChange={handleInputChange}
+          />
+          <NodeField
+            type="text"
+            name="unit"
+            label="単位"
+            value={node.unit}
+            onChange={handleInputChange}
+          />
         </div>
         <div className="flex flex-row space-x-2">
-          <NodeField type="number" label="数値" value={node.value} />
+          <NodeField
+            type="number"
+            name="value"
+            label="数値"
+            value={node.value}
+            onChange={handleInputChange}
+          />
           <NodeField
             type="dropdown"
+            name="valueFormat"
             label="表示形式"
             value={node.value_format}
+            onChange={handleInputChange}
           />
           <div className="ml-8">
             <NodeField
               type="checkbox"
+              name="isValueLocked"
               label="数値を自動更新しない"
               checked={node.is_value_locked}
+              onChange={handleInputChange}
             />
           </div>
         </div>

--- a/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
@@ -19,7 +19,6 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
-    console.log("handleInputChange");
     const name = e.target.name;
     let value: string | number | boolean;
     if (e.target instanceof HTMLInputElement) {
@@ -76,7 +75,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
           />
           <NodeField
             type="dropdown"
-            name="valueFormat"
+            name="value_format"
             label="表示形式"
             value={node.value_format}
             onChange={handleInputChange}
@@ -84,7 +83,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
           <div className="ml-8">
             <NodeField
               type="checkbox"
-              name="isValueLocked"
+              name="is_value_locked"
               label="数値を自動更新しない"
               checked={node.is_value_locked}
               onChange={handleInputChange}

--- a/app/javascript/components/tool/nodeDetailArea/node_field.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/node_field.tsx
@@ -3,6 +3,10 @@ import React from "react";
 type Props = {
   type: "text" | "number" | "checkbox" | "dropdown";
   label: string;
+  name: string;
+  onChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => void;
   placeholder?: string;
   value?: string | number;
   checked?: boolean;
@@ -11,6 +15,8 @@ type Props = {
 const NodeField: React.FC<Props> = ({
   type,
   label,
+  name,
+  onChange,
   placeholder = "",
   value = "",
   checked = false,
@@ -19,13 +25,21 @@ const NodeField: React.FC<Props> = ({
   switch (type) {
     case "checkbox":
       inputElement = (
-        <input type="checkbox" className="checkbox" defaultChecked={checked} />
+        <input
+          type="checkbox"
+          name={name}
+          onChange={onChange}
+          className="checkbox"
+          defaultChecked={checked}
+        />
       );
       break;
     case "number":
       inputElement = (
         <input
           type="number"
+          name={name}
+          onChange={onChange}
           placeholder={placeholder}
           className="input input-bordered input-sm w-24"
           defaultValue={value}
@@ -36,6 +50,8 @@ const NodeField: React.FC<Props> = ({
       inputElement = (
         <input
           type="text"
+          name={name}
+          onChange={onChange}
           placeholder={placeholder}
           className="input input-sm input-bordered w-32"
           defaultValue={value}
@@ -45,6 +61,8 @@ const NodeField: React.FC<Props> = ({
     case "dropdown":
       inputElement = (
         <select
+          name={name}
+          onChange={onChange}
           className="select select-bordered select-sm w-20"
           defaultValue={value}
         >

--- a/app/javascript/components/tool/tool_area.tsx
+++ b/app/javascript/components/tool/tool_area.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { ToolMenu } from "./common/tool_menu";
 import Operations from "./operationArea/operations";
 import Calculation from "./calculationArea/calculation";
@@ -10,8 +10,50 @@ type Props = {
   selectedNodeIds: number[];
 };
 
+export type ToolAreaState = {
+  // operation, culculationResultも後からここに追加する
+  nodes: types.Node[];
+};
+
 const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
+  const [layerProperty, setlayerProperty] = useState<ToolAreaState>({
+    nodes: [
+      {
+        id: 0,
+        name: "",
+        value: 0,
+        unit: "",
+        value_format: "",
+        is_value_locked: false,
+        parent_id: 0,
+      },
+    ],
+  });
+
+  const handleNodeInfoChange = (index: number, newNodeInfo: types.Node) => {
+    const newValues = [...layerProperty.nodes];
+    newValues[index] = newNodeInfo;
+    setlayerProperty({
+      ...layerProperty,
+      nodes: newValues,
+    });
+  };
+
   const { nodes, layers } = treeData;
+
+  useEffect(() => {
+    if (selectedNodeIds.length > 0) {
+      const selectedNodes: types.Node[] = nodes.filter((node) =>
+        selectedNodeIds.includes(node.id)
+      );
+
+      setlayerProperty({
+        ...layerProperty,
+        nodes: selectedNodes,
+      });
+    }
+  }, [selectedNodeIds, nodes]);
+
   if (selectedNodeIds.length === 0) {
     return (
       <div className="p-2 text-center mt-6">
@@ -19,6 +61,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
       </div>
     );
   }
+
   const selectedNodes: types.Node[] = nodes.filter((node) =>
     selectedNodeIds.includes(node.id)
   );
@@ -40,12 +83,13 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
       <>
         <div className="relative flex flex-col h-full">
           <div className="absolute inset-0 overflow-y-auto p-2 pb-20" id="tool">
-            {selectedNodes.map((node, index) => (
+            {layerProperty.nodes.map((node, index) => (
               <NodeDetail
                 key={node.id}
-                order={index + 1}
+                index={index}
                 node={node}
                 isRoot={true}
+                handleNodeInfoChange={handleNodeInfoChange}
               />
             ))}
           </div>
@@ -89,17 +133,18 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
             </div>
             <div className="mb-4">
               <Calculation
-                selectedNodes={selectedNodes}
+                selectedNodes={layerProperty.nodes}
                 selectedLayer={selectedLayer}
                 parentNode={parentNode}
               ></Calculation>
             </div>
-            {selectedNodes.map((node, index) => (
+            {layerProperty.nodes.map((node, index) => (
               <NodeDetail
                 key={node.id}
-                order={index + 1}
+                index={index}
                 node={node}
                 isRoot={false}
+                handleNodeInfoChange={handleNodeInfoChange}
               />
             ))}
             <div className="flex justify-center">

--- a/app/javascript/components/tool/tool_area.tsx
+++ b/app/javascript/components/tool/tool_area.tsx
@@ -11,8 +11,8 @@ type Props = {
 };
 
 export type ToolAreaState = {
-  // operation, culculationResultも後からここに追加する
   nodes: types.Node[];
+  layer: types.Layer | null;
 };
 
 const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
@@ -23,11 +23,17 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
         name: "",
         value: 0,
         unit: "",
-        value_format: "",
+        value_format: "なし",
         is_value_locked: false,
         parent_id: 0,
       },
     ],
+    layer: {
+      id: 0,
+      operation: "multiply",
+      fraction: 0,
+      parent_node_id: 0,
+    },
   });
 
   const handleNodeInfoChange = (index: number, newNodeInfo: types.Node) => {
@@ -135,7 +141,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
             <div className="mb-4">
               <Calculation
                 selectedNodes={layerProperty.nodes}
-                selectedLayer={selectedLayer}
+                operation={selectedLayer.operation}
                 parentNode={parentNode}
               ></Calculation>
             </div>

--- a/app/javascript/components/tool/tool_area.tsx
+++ b/app/javascript/components/tool/tool_area.tsx
@@ -39,11 +39,12 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
     });
   };
 
-  const { nodes, layers } = treeData;
+  const allNodes = treeData.nodes;
+  const allLayers = treeData.layers;
 
   useEffect(() => {
     if (selectedNodeIds.length > 0) {
-      const selectedNodes: types.Node[] = nodes.filter((node) =>
+      const selectedNodes: types.Node[] = allNodes.filter((node) =>
         selectedNodeIds.includes(node.id)
       );
 
@@ -52,7 +53,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
         nodes: selectedNodes,
       });
     }
-  }, [selectedNodeIds, nodes]);
+  }, [selectedNodeIds, allNodes]);
 
   if (selectedNodeIds.length === 0) {
     return (
@@ -62,7 +63,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
     );
   }
 
-  const selectedNodes: types.Node[] = nodes.filter((node) =>
+  const selectedNodes: types.Node[] = allNodes.filter((node) =>
     selectedNodeIds.includes(node.id)
   );
 
@@ -74,7 +75,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
     );
   }
 
-  const parentNode = nodes.find(
+  const parentNode = allNodes.find(
     (node) => node.id === selectedNodes[0].parent_id
   );
 
@@ -104,7 +105,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
     );
   }
 
-  const selectedLayer = layers.find(
+  const selectedLayer = allLayers.find(
     (layer) => layer.parent_node_id === parentNode.id
   );
 

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -11,7 +11,7 @@ export type Node = {
   id: number;
   name: string;
   value: number;
-  value_format: string;
+  value_format: "なし" | "%" | "千" | "万";
   unit: string;
   is_value_locked: boolean;
   operation?: string;


### PR DESCRIPTION
## Issue

close #122 

- https://github.com/peno022/kpi-tree-generator/issues/122

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツールエリアのNodeFieldの入力値をstate管理するようにし、Calculationの表示に反映させた
- 表示のみだったCalculationを、イコールの左辺に右辺の計算結果を出せるようにした
- 計算結果が親ノードの数値と合わない場合に、その差分を吹き出し表示するようにした


## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://127.0.0.1:3001/trees/1/edit にアクセスし、アプリケーションが問題なく立ち上がることを確認する
3. ツリー上のノードをクリックすると、クリックしたノードを含む階層の情報がツールエリアに表示されることを確認する
4. 右側のツールエリアでノードの名前、単位、数値、表示形式の値を編集すると、上部の計算式に値の変更が反映されることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

変更前は右側のツールエリアに値を固定で表示し、編集しても計算式に反映されない状態。

### 変更前

<img width="1430" alt="スクリーンショット 2023-05-27 20 37 12" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/1f78179f-0c79-447e-bd8a-a69fc189fc22">


### 変更後

![Google Chrome - KPI Tree Generator 2023年-05月-27日 20 35 00](https://github.com/peno022/kpi-tree-generator/assets/40317050/a97090dd-e893-4181-b024-f4e716343e1a)
