### PR TITLE
要素間の関係の変更・端数の入力値を計算式に反映できるようにする 

### DIFF
--- a/app/javascript/components/edit_tree_page.tsx
+++ b/app/javascript/components/edit_tree_page.tsx
@@ -38,7 +38,6 @@ const EditTreePage = () => {
   if (isLoading) return <>ロード中…</>;
 
   const handleClick: TreeNodeEventCallback = (node) => {
-    console.log("--- handleClick start ---");
     const clickedNodeId = node.data?.attributes?.id;
     console.log(`id:${clickedNodeId}: ${node.data.name}をクリック`);
 
@@ -55,7 +54,6 @@ const EditTreePage = () => {
       );
       setSelectedNodeIds(siblings.map((node) => node.id));
     }
-    console.log("--- handleClick end ---");
   };
 
   return (

--- a/app/javascript/components/tool/calculationArea/fraction.tsx
+++ b/app/javascript/components/tool/calculationArea/fraction.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 
-type Props = {
+type FractionProps = {
   label: string;
   placeholder?: string;
-  value?: number;
+  value: number;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
-const Fraction: React.FC<Props> = ({ label, placeholder = "", value }) => {
+const Fraction: React.FC<FractionProps> = ({
+  label,
+  placeholder = "",
+  value = 0,
+  onChange,
+}) => {
   return (
     <div className="flex flex-col">
       <div className="text-xs">{label}</div>
@@ -14,7 +20,8 @@ const Fraction: React.FC<Props> = ({ label, placeholder = "", value }) => {
         type="number"
         placeholder={placeholder}
         className="input input-bordered input-xs w-20"
-        defaultValue={value}
+        value={value}
+        onChange={onChange}
       />
     </div>
   );

--- a/app/javascript/components/tool/common/tool_menu.tsx
+++ b/app/javascript/components/tool/common/tool_menu.tsx
@@ -10,7 +10,7 @@ type Props = {
   menuItems: MenuItem[];
 };
 
-export const ToolMenu: React.FC<Props> = ({ menuItems }) => {
+const ToolMenu: React.FC<Props> = ({ menuItems }) => {
   return (
     <>
       <div className="dropdown dropdown-bottom dropdown-end">
@@ -31,3 +31,5 @@ export const ToolMenu: React.FC<Props> = ({ menuItems }) => {
     </>
   );
 };
+
+export default ToolMenu;

--- a/app/javascript/components/tool/layer_tool.tsx
+++ b/app/javascript/components/tool/layer_tool.tsx
@@ -97,7 +97,6 @@ const LayerTool: React.FC<LayerToolProps> = ({
               key={node.id}
               index={index}
               node={node}
-              isRoot={false}
               handleNodeInfoChange={handleNodeInfoChange}
             />
           ))}

--- a/app/javascript/components/tool/layer_tool.tsx
+++ b/app/javascript/components/tool/layer_tool.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from "react";
+import NodeDetail from "./nodeDetailArea/node_detail";
+import { Node, Layer } from "../../types";
+import ToolMenu from "./common/tool_menu";
+import Operations from "./operationArea/operations";
+import Calculation from "./calculationArea/calculation";
+
+type LayerToolProps = {
+  selectedNodes: Node[];
+  selectedLayer: Layer;
+  parentNode: Node;
+};
+
+export type LayerToolState = {
+  nodes: Node[];
+  layer: Layer;
+};
+
+const LayerTool: React.FC<LayerToolProps> = ({
+  selectedNodes,
+  selectedLayer,
+  parentNode,
+}) => {
+  const [layerProperty, setlayerProperty] = useState<LayerToolState>({
+    nodes: selectedNodes,
+    layer: selectedLayer,
+  });
+
+  useEffect(() => {
+    setlayerProperty({
+      ...layerProperty,
+      nodes: selectedNodes,
+      layer: selectedLayer,
+    });
+  }, [selectedNodes, selectedLayer, parentNode]);
+
+  const handleNodeInfoChange = (index: number, newNodeInfo: Node) => {
+    const newValues = [...layerProperty.nodes];
+    newValues[index] = newNodeInfo;
+    setlayerProperty({
+      ...layerProperty,
+      nodes: newValues,
+    });
+  };
+
+  const handleOperationChange = (operation: "multiply" | "add") => {
+    const newLayerValues = { ...layerProperty.layer };
+    newLayerValues.operation = operation;
+    setlayerProperty({
+      ...layerProperty,
+      layer: newLayerValues,
+    });
+  };
+
+  const handleFractionChange = (fraction: number) => {
+    const newLayerValues = { ...layerProperty.layer };
+    newLayerValues.fraction = fraction;
+    setlayerProperty({
+      ...layerProperty,
+      layer: newLayerValues,
+    });
+  };
+
+  return (
+    <>
+      <div className="relative flex flex-col h-full">
+        <div className="absolute inset-0 overflow-y-auto p-2 pb-20" id="tool">
+          <div className="flex justify-between items-center mb-1.5">
+            <div className="text-base font-semibold">要素間の関係</div>
+            <ToolMenu
+              menuItems={[
+                {
+                  label: "階層を削除",
+                  onClick: () => {
+                    console.log("階層を削除");
+                  },
+                },
+              ]}
+            />
+          </div>
+          <div className="mb-4">
+            <Operations
+              selectedLayer={layerProperty.layer}
+              handleOperationChange={handleOperationChange}
+            />
+          </div>
+          <div className="mb-4">
+            <Calculation
+              selectedNodes={layerProperty.nodes}
+              selectedLayer={layerProperty.layer}
+              parentNode={parentNode}
+              handleFractionChange={handleFractionChange}
+            ></Calculation>
+          </div>
+          {layerProperty.nodes.map((node, index) => (
+            <NodeDetail
+              key={node.id}
+              index={index}
+              node={node}
+              isRoot={false}
+              handleNodeInfoChange={handleNodeInfoChange}
+            />
+          ))}
+          <div className="flex justify-center">
+            <button className="btn btn-sm btn-outline">要素を追加</button>
+          </div>
+        </div>
+        <div
+          className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-2"
+          id="updateButton"
+        >
+          <button className="btn btn-primary">更新</button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LayerTool;

--- a/app/javascript/components/tool/message.tsx
+++ b/app/javascript/components/tool/message.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+type MessageProps = {
+  text: string;
+};
+
+const Message: React.FC<MessageProps> = ({ text }) => {
+  return (
+    <div className="p-2 text-center mt-6">
+      <p className="">{text}</p>
+    </div>
+  );
+};
+
+export default Message;

--- a/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import NodeField from "./node_field";
 import { Node } from "../../../types";
-import { ToolMenu } from "../common/tool_menu";
+import ToolMenu from "../common/tool_menu";
 
 type NodeDetailProps = {
   index: number;

--- a/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/node_detail.tsx
@@ -6,14 +6,12 @@ import ToolMenu from "../common/tool_menu";
 type NodeDetailProps = {
   index: number;
   node: Node;
-  isRoot: boolean;
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
 };
 
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,
   node,
-  isRoot = false,
   handleNodeInfoChange,
 }) => {
   const handleInputChange = (
@@ -33,21 +31,17 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
     <>
       <div className="border border-base-300 p-2 my-2">
         <div className="flex justify-between items-center mb-1.5">
-          <div className="text-base font-semibold">
-            {isRoot ? "ルート要素" : `要素${index + 1}`}
-          </div>
-          {!isRoot && (
-            <ToolMenu
-              menuItems={[
-                {
-                  label: "要素を削除",
-                  onClick: () => {
-                    console.log("要素を削除");
-                  },
+          <div className="text-base font-semibold">{`要素${index + 1}`}</div>
+          <ToolMenu
+            menuItems={[
+              {
+                label: "要素を削除",
+                onClick: () => {
+                  console.log("要素を削除");
                 },
-              ]}
-            />
-          )}
+              },
+            ]}
+          />
         </div>
         <div className="flex flex-row space-x-4 mb-1.5">
           <NodeField

--- a/app/javascript/components/tool/nodeDetailArea/root_node_detail.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/root_node_detail.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import NodeField from "./node_field";
+import { Node } from "../../../types";
+import { parentNode } from "../../../../../spec/javascript/__fixtures__/sample_data";
+
+type RootNodeDetailProps = {
+  node: Node;
+  handleNodeInfoChange: (newNodeInfo: Node) => void;
+};
+
+const RootNodeDetail: React.FC<RootNodeDetailProps> = ({
+  node,
+  handleNodeInfoChange,
+}) => {
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const name = e.target.name;
+    let value: string | number | boolean;
+    if (e.target instanceof HTMLInputElement) {
+      value = e.target.type === "checkbox" ? e.target.checked : e.target.value;
+    } else {
+      value = e.target.value;
+    }
+    const updatedNodeInfo = { ...node, [name]: value };
+    handleNodeInfoChange(updatedNodeInfo);
+  };
+  console.log("-----parentNode-------");
+  console.log(parentNode);
+  console.log("-------------------");
+  return (
+    <>
+      <div className="border border-base-300 p-2 my-2">
+        <div className="flex justify-between items-center mb-1.5">
+          <div className="text-base font-semibold">ルート要素</div>
+        </div>
+        <div className="flex flex-row space-x-4 mb-1.5">
+          <NodeField
+            type="text"
+            name="name"
+            label="名前"
+            value={node.name}
+            onChange={handleInputChange}
+          />
+          <NodeField
+            type="text"
+            name="unit"
+            label="単位"
+            value={node.unit}
+            onChange={handleInputChange}
+          />
+        </div>
+        <div className="flex flex-row space-x-2">
+          <NodeField
+            type="number"
+            name="value"
+            label="数値"
+            value={node.value}
+            onChange={handleInputChange}
+          />
+          <NodeField
+            type="dropdown"
+            name="valueFormat"
+            label="表示形式"
+            value={node.valueFormat}
+            onChange={handleInputChange}
+          />
+          <div className="ml-8">
+            <NodeField
+              type="checkbox"
+              name="isValueLocked"
+              label="数値を自動更新しない"
+              checked={node.isValueLocked}
+              onChange={handleInputChange}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default RootNodeDetail;

--- a/app/javascript/components/tool/nodeDetailArea/root_node_detail.tsx
+++ b/app/javascript/components/tool/nodeDetailArea/root_node_detail.tsx
@@ -25,9 +25,7 @@ const RootNodeDetail: React.FC<RootNodeDetailProps> = ({
     const updatedNodeInfo = { ...node, [name]: value };
     handleNodeInfoChange(updatedNodeInfo);
   };
-  console.log("-----parentNode-------");
-  console.log(parentNode);
-  console.log("-------------------");
+
   return (
     <>
       <div className="border border-base-300 p-2 my-2">

--- a/app/javascript/components/tool/operationArea/operations.tsx
+++ b/app/javascript/components/tool/operationArea/operations.tsx
@@ -2,20 +2,18 @@ import React, { useState, useEffect } from "react";
 import Operation from "./operation";
 import { Layer } from "../../../types";
 
-type Props = {
+type OperationsProps = {
   selectedLayer: Layer;
+  handleOperationChange: (operation: "multiply" | "add") => void;
 };
 
-const Operations: React.FC<Props> = ({ selectedLayer }) => {
+const Operations: React.FC<OperationsProps> = ({
+  selectedLayer,
+  handleOperationChange,
+}) => {
   const [selected, setSelected] = useState<"multiply" | "add">("multiply");
 
-  const handleButtonClick = (choice: "multiply" | "add") => {
-    setSelected(choice);
-  };
-
   useEffect(() => {
-    console.log("------ operations.tsx useEffect ------");
-    console.dir(selectedLayer);
     if (selectedLayer.operation === "multiply") {
       setSelected("multiply");
     } else {
@@ -29,15 +27,15 @@ const Operations: React.FC<Props> = ({ selectedLayer }) => {
         <Operation
           isSelected={selected === "multiply"}
           operation="multiply"
-          onClick={() => handleButtonClick("multiply")}
+          onClick={() => handleOperationChange("multiply")}
         />
       </div>
 
-      <div onClick={() => handleButtonClick("add")}>
+      <div>
         <Operation
           isSelected={selected === "add"}
           operation="add"
-          onClick={() => handleButtonClick("add")}
+          onClick={() => handleOperationChange("add")}
         />
       </div>
     </div>

--- a/app/javascript/components/tool/root_node_tool.tsx
+++ b/app/javascript/components/tool/root_node_tool.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from "react";
+import RootNodeDetail from "./nodeDetailArea/root_node_detail";
+import { Node } from "../../types";
+
+type RootNodeToolProps = {
+  selectedRootNode: Node;
+};
+
+const RootNodeTool: React.FC<RootNodeToolProps> = ({ selectedRootNode }) => {
+  const [nodeInfo, setNodeInfo] = useState<Node>(selectedRootNode);
+
+  const handleNodeInfoChange = (updatedNodeInfo: Node) => {
+    setNodeInfo(updatedNodeInfo);
+  };
+  return (
+    <>
+      <div className="relative flex flex-col h-full">
+        <div className="absolute inset-0 overflow-y-auto p-2 pb-20" id="tool">
+          <RootNodeDetail
+            node={nodeInfo}
+            handleNodeInfoChange={handleNodeInfoChange}
+          />
+        </div>
+        <div
+          className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-2"
+          id="updateButton"
+        >
+          <button className="btn btn-primary">更新</button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default RootNodeTool;

--- a/app/javascript/components/tool/tool_area.tsx
+++ b/app/javascript/components/tool/tool_area.tsx
@@ -1,72 +1,20 @@
-import React, { useState, useEffect } from "react";
-import { ToolMenu } from "./common/tool_menu";
-import Operations from "./operationArea/operations";
-import Calculation from "./calculationArea/calculation";
-import NodeDetail from "./nodeDetailArea/node_detail";
+import React from "react";
 import * as types from "../../types";
+import RootNodeTool from "./root_node_tool";
+import LayerTool from "./layer_tool";
+import Message from "./message";
 
-type Props = {
+type ToolAreaProps = {
   treeData: types.TreeData;
   selectedNodeIds: number[];
 };
 
-export type ToolAreaState = {
-  nodes: types.Node[];
-  layer: types.Layer | null;
-};
-
-const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
-  const [layerProperty, setlayerProperty] = useState<ToolAreaState>({
-    nodes: [
-      {
-        id: 0,
-        name: "",
-        value: 0,
-        unit: "",
-        valueFormat: "なし",
-        isValueLocked: false,
-        parentId: 0,
-      },
-    ],
-    layer: {
-      id: 0,
-      operation: "multiply",
-      fraction: 0,
-      parentNodeId: 0,
-    },
-  });
-
-  const handleNodeInfoChange = (index: number, newNodeInfo: types.Node) => {
-    const newValues = [...layerProperty.nodes];
-    newValues[index] = newNodeInfo;
-    setlayerProperty({
-      ...layerProperty,
-      nodes: newValues,
-    });
-  };
-
+const ToolArea: React.FC<ToolAreaProps> = ({ treeData, selectedNodeIds }) => {
   const allNodes = treeData.nodes;
   const allLayers = treeData.layers;
 
-  useEffect(() => {
-    if (selectedNodeIds.length > 0) {
-      const selectedNodes: types.Node[] = allNodes.filter((node) =>
-        selectedNodeIds.includes(node.id)
-      );
-
-      setlayerProperty({
-        ...layerProperty,
-        nodes: selectedNodes,
-      });
-    }
-  }, [selectedNodeIds, allNodes]);
-
   if (selectedNodeIds.length === 0) {
-    return (
-      <div className="p-2 text-center mt-6">
-        <p className="">要素を選択すると、ここに詳細が表示されます。</p>
-      </div>
-    );
+    return <Message text="要素を選択すると、ここに詳細が表示されます。" />;
   }
 
   const selectedNodes: types.Node[] = allNodes.filter((node) =>
@@ -74,11 +22,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
   );
 
   if (selectedNodes.length === 0) {
-    return (
-      <div className="p-2 text-center mt-6">
-        <p className="">選択されたノードIDが不正です。</p>
-      </div>
-    );
+    return <Message text="選択されたノードIDが不正です。" />;
   }
 
   const parentNode = allNodes.find(
@@ -86,29 +30,7 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
   );
 
   if (!parentNode) {
-    return (
-      <>
-        <div className="relative flex flex-col h-full">
-          <div className="absolute inset-0 overflow-y-auto p-2 pb-20" id="tool">
-            {layerProperty.nodes.map((node, index) => (
-              <NodeDetail
-                key={node.id}
-                index={index}
-                node={node}
-                isRoot={true}
-                handleNodeInfoChange={handleNodeInfoChange}
-              />
-            ))}
-          </div>
-          <div
-            className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-2"
-            id="updateButton"
-          >
-            <button className="btn btn-primary">更新</button>
-          </div>
-        </div>
-      </>
-    );
+    return <RootNodeTool selectedRootNode={selectedNodes[0]} />;
   }
 
   const selectedLayer = allLayers.find(
@@ -116,56 +38,14 @@ const ToolArea: React.FC<Props> = ({ treeData, selectedNodeIds }) => {
   );
 
   if (!selectedLayer) {
-    return <>存在しない階層です。</>;
+    return <Message text="存在しない階層です。" />;
   } else {
     return (
-      <>
-        <div className="relative flex flex-col h-full">
-          <div className="absolute inset-0 overflow-y-auto p-2 pb-20" id="tool">
-            <div className="flex justify-between items-center mb-1.5">
-              <div className="text-base font-semibold">要素間の関係</div>
-              <ToolMenu
-                menuItems={[
-                  {
-                    label: "階層を削除",
-                    onClick: () => {
-                      console.log("階層を削除");
-                    },
-                  },
-                ]}
-              />
-            </div>
-            <div className="mb-4">
-              <Operations selectedLayer={selectedLayer} />
-            </div>
-            <div className="mb-4">
-              <Calculation
-                selectedNodes={layerProperty.nodes}
-                operation={selectedLayer.operation}
-                parentNode={parentNode}
-              ></Calculation>
-            </div>
-            {layerProperty.nodes.map((node, index) => (
-              <NodeDetail
-                key={node.id}
-                index={index}
-                node={node}
-                isRoot={false}
-                handleNodeInfoChange={handleNodeInfoChange}
-              />
-            ))}
-            <div className="flex justify-center">
-              <button className="btn btn-sm btn-outline">要素を追加</button>
-            </div>
-          </div>
-          <div
-            className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-2"
-            id="updateButton"
-          >
-            <button className="btn btn-primary">更新</button>
-          </div>
-        </div>
-      </>
+      <LayerTool
+        selectedNodes={selectedNodes}
+        selectedLayer={selectedLayer}
+        parentNode={parentNode}
+      ></LayerTool>
     );
   }
 };

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -3,7 +3,7 @@ import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
 export type Layer = {
   id: number;
   operation: "multiply" | "add";
-  fraction: number | null;
+  fraction: number;
   parentNodeId: number;
 };
 

--- a/spec/javascript/__fixtures__/sample_data.ts
+++ b/spec/javascript/__fixtures__/sample_data.ts
@@ -35,7 +35,7 @@ export const childNode2: Node = {
 export const childLayer: Layer = {
   id: 1,
   operation: "add",
-  fraction: null,
+  fraction: 0,
   parentNodeId: 1,
 };
 
@@ -62,6 +62,6 @@ export const grandChildNode2: Node = {
 export const grandChildLayer: Layer = {
   id: 2,
   operation: "multiply",
-  fraction: null,
+  fraction: 0,
   parentNodeId: 2,
 };


### PR DESCRIPTION
## Issue

close #173 

- https://github.com/peno022/kpi-tree-generator/issues/173

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 階層の選択状態に応じた条件分岐、入力値の状態管理、画面の表示をすべてToolAreaコンポーネントで行っていたが、条件分岐後の画面表示と入力値の管理はそれぞれ別なコンポーネントに切り出すように変更。
  - ノードの選択状態（またはエラー発生状態）に応じて`Message`、`RootNodeTool`、`LayerTool`のコンポーネントを表示するようにした。
  - stateとイベントハンドラもそれぞれのコンポーネントに移動。
- 上記の変更を行ったうえで、`fraction`と`operation`について、stateを参照し、変更時にイベントハンドラが呼ばれるようにした。
- `ToolMenu`コンポーネントを他とあわせてexport defaultに変更しておいた。
- 過去にデバッグ用に入れたconsole.logでもう不要になっているものを削除した。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://127.0.0.1:3001/trees/1/edit にアクセスし、アプリケーションが問題なく立ち上がることを確認する
3. 任意のノードを選択し、ツールエリアで「要素間の関係」と「端数」を編集すると計算式に変更が反映されていることを確認する
4. ルートノードを選択し、ツールエリア表示にルートノードの情報が（この対応以前と変わらずに）表示されていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![Google Chrome - KPI Tree Generator 2023年-05月-28日 18 05 17](https://github.com/peno022/kpi-tree-generator/assets/40317050/3ab4a814-dd80-4195-9ec1-4fa7dd1c2182)

### 変更後

![Google Chrome - KPI Tree Generator 2023年-05月-28日 18 03 40](https://github.com/peno022/kpi-tree-generator/assets/40317050/7fb74909-70dd-4ca4-8ac4-40eaffd3e1de)
