### PR TITLE
ノード追加機能

### DIFF
--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -42,17 +42,26 @@ module Api
 
     def assign_nodes_attributes
       @nodes = tree_params[:nodes].map do |node_param|
-        node = @tree.nodes.find(node_param[:id])
-        node.assign_attributes(node_param.slice(:name, :value, :value_format, :unit, :is_value_locked))
+        node = if node_param[:id]
+                 @tree.nodes.find(node_param[:id])
+               else
+                 Node.new(tree_id: @tree.id)
+               end
+        node.assign_attributes(node_param.slice(:name, :value, :value_format, :unit, :is_value_locked, :parent_id))
         node
       end
     end
 
     def assign_layers_attributes
       @layers = tree_params[:layers].map do |layer_param|
-        layer = @tree.layers.find(layer_param[:id])
+        layer = if layer_param[:id]
+                  @tree.layers.find(layer_param[:id])
+                else
+                  Layer.new(tree_id: @tree.id)
+                end
         layer.operation = layer_param[:operation]
         layer.fraction = layer_param[:fraction] || 0
+        layer.parent_node_id = layer_param[:parent_node_id]
         layer
       end
     end

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -18,15 +18,7 @@ type LayerToolProps = {
 };
 
 export type LayerToolState = {
-  nodes: {
-    id?: number;
-    name: string;
-    value: number;
-    valueFormat: "なし" | "%" | "千" | "万";
-    unit: string;
-    isValueLocked: boolean;
-    parentId: number;
-  }[];
+  nodes: Node[];
   layer: Layer;
 };
 
@@ -130,6 +122,28 @@ const LayerTool: React.FC<LayerToolProps> = ({
     });
   };
 
+  const addNode = () => {
+    const newNodes = [...layerProperty.nodes];
+    let initialValue: number;
+    if (layerProperty.layer.operation === "multiply") {
+      initialValue = 1;
+    } else {
+      initialValue = 0;
+    }
+    newNodes.push({
+      name: `要素${newNodes.length + 1}`,
+      value: initialValue,
+      unit: "",
+      valueFormat: "なし",
+      isValueLocked: false,
+      parentId: parentNode.id,
+    });
+    setlayerProperty({
+      ...layerProperty,
+      nodes: newNodes,
+    });
+  };
+
   const saveLayerProperty = async () => {
     const result = await sendUpdateRequest(
       propagateSelectedNodesChangesToTree(
@@ -190,7 +204,9 @@ const LayerTool: React.FC<LayerToolProps> = ({
             />
           ))}
           <div className="flex justify-center">
-            <button className="btn btn-sm btn-outline mt-2">要素を追加</button>
+            <button className="btn btn-sm btn-outline mt-2" onClick={addNode}>
+              要素を追加
+            </button>
           </div>
         </div>
         <div

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import NodeDetail from "@/components/trees/tool/nodeDetailArea/NodeDetail";
-import { Node, Layer, TreeData } from "@/types";
+import { Node, Layer, NodeFromApi, TreeDataFromApi } from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
 import Operations from "@/components/trees/tool/operationArea/Operations";
 import Calculation from "@/components/trees/tool/calculationArea/Calculation";
@@ -10,15 +10,23 @@ import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
 
 type LayerToolProps = {
-  selectedNodes: Node[];
+  selectedNodes: NodeFromApi[];
   selectedLayer: Layer;
-  parentNode: Node;
-  onUpdateSuccess: (updatedTreeData: TreeData) => void;
-  treeData: TreeData;
+  parentNode: NodeFromApi;
+  onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
+  treeData: TreeDataFromApi;
 };
 
 export type LayerToolState = {
-  nodes: Node[];
+  nodes: {
+    id?: number;
+    name: string;
+    value: number;
+    valueFormat: "なし" | "%" | "千" | "万";
+    unit: string;
+    isValueLocked: boolean;
+    parentId: number;
+  }[];
   layer: Layer;
 };
 

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -196,7 +196,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
           </div>
           {layerProperty.nodes.map((node, index) => (
             <NodeDetail
-              key={node.id}
+              key={index}
               index={index}
               node={node}
               handleNodeInfoChange={handleNodeInfoChange}

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from "react";
 import NodeDetail from "@/components/trees/tool/nodeDetailArea/NodeDetail";
 import OpenModalButton from "@/components/shared/OpenModalButton";
-import { Node, TreeData } from "@/types";
+import { Node, NodeFromApi, TreeDataFromApi, TreeData } from "@/types";
 import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
 
 type RootNodeToolProps = {
-  selectedRootNode: Node;
-  onUpdateSuccess: (updatedTreeData: TreeData) => void;
-  treeData: TreeData;
+  selectedRootNode: NodeFromApi;
+  onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
+  treeData: TreeDataFromApi;
 };
 
 const RootNodeTool: React.FC<RootNodeToolProps> = ({
@@ -33,6 +33,12 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
 
   const saveNodeInfo = async () => {
     setErrorMessage(null);
+    if (nodeInfo.id === undefined || nodeInfo.id === null) {
+      setErrorMessage(
+        "システムエラーが発生しました。画面を再読み込みしてもう一度お試しください。"
+      );
+      return;
+    }
     const newNodes = treeData.nodes.map((node) => {
       if (node.id === nodeInfo.id) {
         return nodeInfo;

--- a/app/javascript/components/trees/tool/ToolArea.tsx
+++ b/app/javascript/components/trees/tool/ToolArea.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { TreeData, Node } from "@/types";
+import { TreeDataFromApi, NodeFromApi } from "@/types";
 import RootNodeTool from "@/components/trees/tool/RootNodeTool";
 import LayerTool from "@/components/trees/tool/LayerTool";
 import Message from "@/components/trees/tool/Message";
 
 export type ToolAreaProps = {
-  treeData: TreeData;
+  treeData: TreeDataFromApi;
   selectedNodeIds: number[];
-  onUpdateSuccess: (updatedTreeData: TreeData) => void;
+  onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
 };
 
 export const ToolArea: React.FC<ToolAreaProps> = ({
@@ -22,12 +22,14 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
     return <Message text="要素を選択すると、ここに詳細が表示されます。" />;
   }
 
-  const selectedNodes: Node[] = allNodes.filter((node) =>
+  const selectedNodes: NodeFromApi[] = allNodes.filter((node) =>
     selectedNodeIds.includes(node.id)
   );
 
   if (selectedNodes.length === 0) {
-    return <Message text="選択されたノードIDが不正です。" />;
+    return (
+      <Message text="選択された要素のIDが不正です。画面を再読み込みしてもう一度お試しください。" />
+    );
   }
 
   const parentNode = allNodes.find(

--- a/app/javascript/components/trees/tool/calculationArea/Calculation.tsx
+++ b/app/javascript/components/trees/tool/calculationArea/Calculation.tsx
@@ -25,7 +25,7 @@ const Calculation: React.FC<CalculationProps> = ({
   fractionErrorMessage,
   handleFractionChange,
 }) => {
-  const maxId = Math.max(...selectedNodes.map((node) => node.id));
+  const maxIndex = selectedNodes.length - 1;
   const [calculationResult, setCalculationResult] = useState(0);
 
   useEffect(() => {
@@ -56,7 +56,7 @@ const Calculation: React.FC<CalculationProps> = ({
                 displayUnit={getDisplayUnit(node)}
                 elementId={index}
               />
-              {!(node.id === maxId) && (
+              {!(index === maxIndex) && (
                 <OperationSymbol operation={selectedLayer.operation} />
               )}
             </div>

--- a/app/javascript/components/trees/tree/TreeArea.tsx
+++ b/app/javascript/components/trees/tree/TreeArea.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
 import { selectNodes } from "@/selectNodes";
 import Tree from "react-d3-tree";
-import { TreeData } from "@/types";
+import { TreeDataFromApi } from "@/types";
 import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
 import { TreeNodeEventCallback } from "react-d3-tree/lib/types/Tree/types";
 import CustomNode from "@/components/trees/tree/CustomNode";
 
 export type TreeAreaProps = {
-  treeData: TreeData;
+  treeData: TreeDataFromApi;
   selectedNodeIds: number[];
   handleClick: TreeNodeEventCallback;
 };

--- a/app/javascript/convertNodesToRawNodeDatum.ts
+++ b/app/javascript/convertNodesToRawNodeDatum.ts
@@ -4,15 +4,15 @@ import LTT from "list-to-tree";
 
 export {};
 
-type preparedNode = types.Node & {
+type preparedNode = types.NodeFromApi & {
   operation?: string;
   isLastInLayer?: boolean;
-  childLayer?: types.Layer;
+  childLayer?: types.LayerFromApi;
 };
 
 export function convertNodesToRawNodeDatum(
-  nodes: types.Node[],
-  layers: types.Layer[]
+  nodes: types.NodeFromApi[],
+  layers: types.LayerFromApi[]
 ): RawNodeDatum {
   const preparedNodes = prepareNodeProperties(nodes, layers);
   const treeStructureNode = convertNodesListToTree(preparedNodes);
@@ -23,8 +23,8 @@ export function convertNodesToRawNodeDatum(
 }
 
 function prepareNodeProperties(
-  nodes: types.Node[],
-  layers: types.Layer[]
+  nodes: types.NodeFromApi[],
+  layers: types.LayerFromApi[]
 ): preparedNode[] {
   const nodesWithIsLastInLayerProperty = addIsLastInLayerProperty(nodes);
   const nodesWithChildLayer = addLayerToNode(
@@ -37,7 +37,9 @@ function prepareNodeProperties(
   return nodesWithInheritedOperation;
 }
 
-function convertNodesListToTree(nodes: types.Node[]): types.TreeStructureNode {
+function convertNodesListToTree(
+  nodes: preparedNode[]
+): types.TreeStructureNode {
   // nodesのparentIdがnullの場合、parentIdを0に変更する
   nodes.forEach((node) => {
     if (node.parentId === null) {
@@ -55,7 +57,7 @@ function convertNodesListToTree(nodes: types.Node[]): types.TreeStructureNode {
 }
 
 // 自分がchildrenの中の最後のノードかどうかを判定し、isLastInLayerプロパティを追加する関数
-function addIsLastInLayerProperty(nodes: types.Node[]): preparedNode[] {
+function addIsLastInLayerProperty(nodes: types.NodeFromApi[]): preparedNode[] {
   return nodes.map((node) => {
     const nodeWithIsLastInLayerProperty = { ...node, isLastInLayer: false };
     const parentNode = findNodeById(node.parentId, nodes);
@@ -78,7 +80,7 @@ function addIsLastInLayerProperty(nodes: types.Node[]): preparedNode[] {
 // LayerのparentNodeIdをidに持つNodeを探し、そのNodeのプロパティにchildLayerを追加する関数
 function addLayerToNode(
   nodes: preparedNode[],
-  layers: types.Layer[]
+  layers: types.LayerFromApi[]
 ): preparedNode[] {
   layers.forEach((layer) => {
     const parentNode = findNodeById(layer.parentNodeId, nodes);

--- a/app/javascript/fetcher.ts
+++ b/app/javascript/fetcher.ts
@@ -1,6 +1,8 @@
 import * as types from "@/types";
 
-export default async function fetcher(url: URL): Promise<types.TreeData> {
+export default async function fetcher(
+  url: URL
+): Promise<types.TreeDataFromApi> {
   const res = await fetch(url);
   return await res.json();
 }

--- a/app/javascript/hooks/useTreeUpdate.ts
+++ b/app/javascript/hooks/useTreeUpdate.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { TreeData } from "@/types";
+import { TreeData, TreeDataFromApi } from "@/types";
 import keysToSnakeCase from "@/keysToSnakeCase";
 import keysToCamelCase from "@/keysToCamelCase";
 import nullifyParentNodeId from "@/nullifyParentNodeId";
@@ -7,7 +7,7 @@ import token from "@/token";
 
 export type TreeUpdateHook = {
   errorMessage: string | null;
-  sendUpdateRequest: (treeData: TreeData) => Promise<TreeData | null>;
+  sendUpdateRequest: (treeData: TreeData) => Promise<TreeDataFromApi | null>;
   setErrorMessage: React.Dispatch<React.SetStateAction<string | null>>;
 };
 

--- a/app/javascript/hooks/useTreeUpdate.ts
+++ b/app/javascript/hooks/useTreeUpdate.ts
@@ -53,6 +53,7 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
       }
     }
     const json = await response.json();
+    console.dir(json);
     return keysToCamelCase(json);
   };
 

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import ToolArea from "@/components/trees/tool/ToolArea";
 import { TreeArea } from "@/components/trees/tree/TreeArea";
 import { TreeNodeEventCallback } from "react-d3-tree/lib/types/Tree/types";
-import { TreeData } from "@/types";
+import { TreeDataFromApi } from "@/types";
 import { ErrorBoundary } from "react-error-boundary";
 import { FallbackProps } from "react-error-boundary/dist/react-error-boundary";
 import keysToCamelCase from "@/keysToCamelCase";
@@ -11,7 +11,7 @@ import keysToCamelCase from "@/keysToCamelCase";
 const EditTreePage = () => {
   const treeId = document.getElementById("tree")?.getAttribute("data-tree-id");
 
-  const [treeData, setTreeData] = useState<TreeData>({
+  const [treeData, setTreeData] = useState<TreeDataFromApi>({
     tree: { id: 0, name: "" },
     nodes: [],
     layers: [],
@@ -57,7 +57,7 @@ const EditTreePage = () => {
     }
   };
 
-  const handleUpdateSuccess = (updatedTreeData: TreeData) => {
+  const handleUpdateSuccess = (updatedTreeData: TreeDataFromApi) => {
     setTreeData(updatedTreeData);
     setSelectedNodeIds([]);
   };

--- a/app/javascript/propagateSelectedNodesChangesToTree.ts
+++ b/app/javascript/propagateSelectedNodesChangesToTree.ts
@@ -1,21 +1,25 @@
-import { Node, Layer, TreeData } from "@/types";
+import { Node, Layer, TreeData, TreeDataFromApi } from "@/types";
 import calculateParentNodeValue from "@/calculateParentNodeValue";
 
 export default function propagateSelectedNodesChangesToTree(
   selectedNodes: Node[],
   selectedLayer: Layer,
-  treeData: TreeData
+  treeData: TreeDataFromApi
 ): TreeData {
   const updatedTreeData: TreeData = JSON.parse(JSON.stringify(treeData));
 
   selectedNodes.forEach((node) => {
-    const updatedNode = updatedTreeData.nodes.find((n) => n.id === node.id);
-    if (!updatedNode) return;
-    updatedNode.name = node.name;
-    updatedNode.value = node.value;
-    updatedNode.valueFormat = node.valueFormat;
-    updatedNode.unit = node.unit;
-    updatedNode.isValueLocked = node.isValueLocked;
+    if (node.id === undefined || node.id === null) {
+      updatedTreeData.nodes.push(node);
+    } else {
+      const updatedNode = updatedTreeData.nodes.find((n) => n.id === node.id);
+      if (!updatedNode) return;
+      updatedNode.name = node.name;
+      updatedNode.value = node.value;
+      updatedNode.valueFormat = node.valueFormat;
+      updatedNode.unit = node.unit;
+      updatedNode.isValueLocked = node.isValueLocked;
+    }
   });
 
   const updatedLayer = updatedTreeData.layers.find(

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -1,6 +1,13 @@
 import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
 
 export type Layer = {
+  id?: number;
+  operation: "multiply" | "add";
+  fraction: number;
+  parentNodeId: number;
+};
+
+export type LayerFromApi = {
   id: number;
   operation: "multiply" | "add";
   fraction: number;
@@ -8,6 +15,16 @@ export type Layer = {
 };
 
 export type Node = {
+  id?: number;
+  name: string;
+  value: number;
+  valueFormat: "なし" | "%" | "千" | "万";
+  unit: string;
+  isValueLocked: boolean;
+  parentId: number;
+};
+
+export type NodeFromApi = {
   id: number;
   name: string;
   value: number;
@@ -26,7 +43,7 @@ export type TreeStructureNode = {
   isValueLocked: boolean;
   operation: string;
   isLastInLayer: boolean;
-  childLayer?: Layer;
+  childLayer?: LayerFromApi;
   parentId: number;
   children: TreeStructureNode[];
 };
@@ -46,6 +63,12 @@ export type WrappedRawNodeDatum = RawNodeDatum & {
 export type Tree = {
   id: number;
   name: string;
+};
+
+export type TreeDataFromApi = {
+  tree: Tree;
+  nodes: NodeFromApi[];
+  layers: LayerFromApi[];
 };
 
 export type TreeData = {

--- a/spec/javascript/__fixtures__/sampleData.ts
+++ b/spec/javascript/__fixtures__/sampleData.ts
@@ -1,4 +1,4 @@
-import { Node, Layer, Tree, TreeData } from "@/types";
+import { NodeFromApi, LayerFromApi, Tree, TreeDataFromApi } from "@/types";
 
 export {};
 
@@ -7,7 +7,7 @@ export const tree: Tree = {
   name: "ツリー1",
 };
 
-export const parentNode: Node = {
+export const parentNode: NodeFromApi = {
   id: 1,
   name: "親ノード",
   value: 300,
@@ -17,7 +17,7 @@ export const parentNode: Node = {
   parentId: 0,
 };
 
-export const childNode1: Node = {
+export const childNode1: NodeFromApi = {
   id: 2,
   name: "子ノード1",
   value: 100,
@@ -27,7 +27,7 @@ export const childNode1: Node = {
   parentId: 1,
 };
 
-export const childNode2: Node = {
+export const childNode2: NodeFromApi = {
   id: 3,
   name: "子ノード2",
   value: 200,
@@ -37,14 +37,14 @@ export const childNode2: Node = {
   parentId: 1,
 };
 
-export const childLayer: Layer = {
+export const childLayer: LayerFromApi = {
   id: 1,
   operation: "add",
   fraction: 0,
   parentNodeId: 1,
 };
 
-export const grandChildNode1: Node = {
+export const grandChildNode1: NodeFromApi = {
   id: 4,
   name: "孫ノード1",
   value: 1000,
@@ -54,7 +54,7 @@ export const grandChildNode1: Node = {
   parentId: 2,
 };
 
-export const grandChildNode2: Node = {
+export const grandChildNode2: NodeFromApi = {
   id: 5,
   name: "孫ノード2",
   value: 10,
@@ -64,14 +64,14 @@ export const grandChildNode2: Node = {
   parentId: 2,
 };
 
-export const grandChildLayer: Layer = {
+export const grandChildLayer: LayerFromApi = {
   id: 2,
   operation: "multiply",
   fraction: 0,
   parentNodeId: 2,
 };
 
-export const greatGrandChildNode1: Node = {
+export const greatGrandChildNode1: NodeFromApi = {
   id: 6,
   name: "ひ孫ノード1",
   value: 950,
@@ -81,7 +81,7 @@ export const greatGrandChildNode1: Node = {
   parentId: 4,
 };
 
-export const greatGrandChildNode2: Node = {
+export const greatGrandChildNode2: NodeFromApi = {
   id: 7,
   name: "ひ孫ノード2",
   value: 20,
@@ -91,7 +91,7 @@ export const greatGrandChildNode2: Node = {
   parentId: 4,
 };
 
-export const greatGrandChildNode3: Node = {
+export const greatGrandChildNode3: NodeFromApi = {
   id: 8,
   name: "ひ孫ノード3",
   value: 30,
@@ -101,14 +101,14 @@ export const greatGrandChildNode3: Node = {
   parentId: 4,
 };
 
-export const greatGrandChildLayer: Layer = {
+export const greatGrandChildLayer: LayerFromApi = {
   id: 3,
   operation: "add",
   fraction: 0,
   parentNodeId: 4,
 };
 
-export const treeData: TreeData = {
+export const treeData: TreeDataFromApi = {
   tree,
   nodes: [
     parentNode,

--- a/spec/javascript/components/trees/tool/ToolArea.spec.tsx
+++ b/spec/javascript/components/trees/tool/ToolArea.spec.tsx
@@ -64,7 +64,7 @@ describe("ノードが選択されていないとき", () => {
 
 describe("正常なデータでは起きないはずのエラー", () => {
   describe("選択したノードIDに該当するノードがツリーに存在しないとき", () => {
-    it("'選択されたノードIDが不正です。'というテキストが表示されること", () => {
+    it("'選択された要素のIDが不正です。'というテキストが表示されること", () => {
       const toolAreaProps: ToolAreaProps = {
         treeData: fixtures.treeData,
         selectedNodeIds: [999999, 9999999],
@@ -72,7 +72,9 @@ describe("正常なデータでは起きないはずのエラー", () => {
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(
-        screen.getByText("選択されたノードIDが不正です。")
+        screen.getByText(
+          "選択された要素のIDが不正です。画面を再読み込みしてもう一度お試しください。"
+        )
       ).toBeInTheDocument();
     });
   });

--- a/spec/javascript/convertNodesToRawNodeDatum.spec.ts
+++ b/spec/javascript/convertNodesToRawNodeDatum.spec.ts
@@ -4,7 +4,7 @@
 
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
 import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
-import { Node, Layer } from "@/types";
+import { LayerFromApi, NodeFromApi } from "@/types";
 import * as fixtures from "@spec/__fixtures__/sampleData";
 
 const {
@@ -20,8 +20,8 @@ const {
 describe("convertNodesToRawNodeDatum", () => {
   describe("Childrenがない単体のノード", () => {
     it("単体ノード1つに対して、1つのRawNodeDatumを返す", () => {
-      const nodes: Node[] = [parentNode];
-      const layers: Layer[] = [];
+      const nodes: NodeFromApi[] = [parentNode];
+      const layers: LayerFromApi[] = [];
       const expected: RawNodeDatum = {
         name: parentNode.name,
         attributes: {
@@ -39,8 +39,8 @@ describe("convertNodesToRawNodeDatum", () => {
   });
   describe("Childrenがあるノード", () => {
     it("子ノードのRawNodeDatumをchildrenに持つRawNodeDatumを返す", () => {
-      const nodes: Node[] = [parentNode, childNode1, childNode2];
-      const layers: Layer[] = [childLayer];
+      const nodes: NodeFromApi[] = [parentNode, childNode1, childNode2];
+      const layers: LayerFromApi[] = [childLayer];
       const expected: RawNodeDatum = {
         name: parentNode.name,
         attributes: {
@@ -84,14 +84,14 @@ describe("convertNodesToRawNodeDatum", () => {
   });
   describe("孫ノードがあるノード", () => {
     it("孫ノードのRawNodeDatumをchildrenに持つRawNodeDatumを返す", () => {
-      const nodes: Node[] = [
+      const nodes: NodeFromApi[] = [
         parentNode,
         childNode1,
         childNode2,
         grandChildNode1,
         grandChildNode2,
       ];
-      const layers: Layer[] = [childLayer, grandChildLayer];
+      const layers: LayerFromApi[] = [childLayer, grandChildLayer];
       const expected: RawNodeDatum = {
         name: parentNode.name,
         attributes: {

--- a/spec/javascript/propagateSelectedNodesChangesToTree.spec.ts
+++ b/spec/javascript/propagateSelectedNodesChangesToTree.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import propagateSelectedNodesChangesToTree from "@/propagateSelectedNodesChangesToTree";
-import { Node, Layer, TreeData } from "@/types";
+import { Node, Layer, TreeDataFromApi } from "@/types";
 import * as fixtures from "@spec/__fixtures__/sampleData";
 
 describe("propagateSelectedNodesChangesToTree", () => {
@@ -23,7 +23,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
     } = JSON.parse(JSON.stringify(fixtures));
     parentNode.isValueLocked = false;
 
-    const treeData: TreeData = {
+    const treeData: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         parentNode,
@@ -59,7 +59,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
       treeData
     );
 
-    const expected: TreeData = {
+    const expected: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         {
@@ -128,7 +128,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
     parentNode.isValueLocked = false;
     grandChildNode1.isValueLocked = true;
 
-    const treeData: TreeData = {
+    const treeData: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         parentNode,
@@ -164,7 +164,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
       treeData
     );
 
-    const expected: TreeData = {
+    const expected: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         {
@@ -228,7 +228,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
     parentNode.isValueLocked = false;
     childNode1.isValueLocked = true;
 
-    const treeData: TreeData = {
+    const treeData: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         parentNode,
@@ -264,7 +264,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
       treeData
     );
 
-    const expected: TreeData = {
+    const expected: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         {
@@ -333,7 +333,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
     parentNode.isValueLocked = false;
     greatGrandChildNode1.isValueLocked = true;
 
-    const treeData: TreeData = {
+    const treeData: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         parentNode,
@@ -369,7 +369,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
       treeData
     );
 
-    const expected: TreeData = {
+    const expected: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         {
@@ -437,7 +437,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
     } = JSON.parse(JSON.stringify(fixtures));
     parentNode.isValueLocked = true;
 
-    const treeData: TreeData = {
+    const treeData: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         parentNode,
@@ -473,7 +473,7 @@ describe("propagateSelectedNodesChangesToTree", () => {
       treeData
     );
 
-    const expected: TreeData = {
+    const expected: TreeDataFromApi = {
       tree: { id: 1, name: "Tree1" },
       nodes: [
         {

--- a/spec/javascript/selectNodes.spec.ts
+++ b/spec/javascript/selectNodes.spec.ts
@@ -4,7 +4,7 @@
 
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
 import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
-import { Node, Layer } from "@/types";
+import { NodeFromApi, LayerFromApi } from "@/types";
 import * as fixtures from "@spec/__fixtures__/sampleData";
 import { selectNodes } from "@/selectNodes";
 
@@ -17,14 +17,14 @@ const {
   grandChildNode2,
   grandChildLayer,
 } = fixtures;
-const nodes: Node[] = [
+const nodes: NodeFromApi[] = [
   parentNode,
   childNode1,
   childNode2,
   grandChildNode1,
   grandChildNode2,
 ];
-const layers: Layer[] = [childLayer, grandChildLayer];
+const layers: LayerFromApi[] = [childLayer, grandChildLayer];
 const rawNodeDatum = convertNodesToRawNodeDatum(nodes, layers);
 
 describe("selectNodes", () => {

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
     click_button 'Googleでログイン'
   end
 
-  describe('選択した階層のプロパティを編集・更新') do
+  describe('選択した階層のノードのプロパティを編集・更新') do
     before do
       # データの作成
       tree = create(:tree, user: User.find_by(uid: '1234'))
@@ -31,31 +31,28 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: false
       )
 
-      child_node1_svg_after = find('g > text', text: '子1').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_svg_after,
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: true
       )
 
-      child_node2_svg_after = find('g > text', text: '子2').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node2_svg_after,
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
-        operation: ''
+        operation: '',
+        is_leaf: true
       )
 
       # 要素未選択状態に戻り、ツールエリアが閉じていることを確認
@@ -84,30 +81,27 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: false
       )
-      child_node1_svg_after = find('g > text', text: '変更後のノード名1').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_svg_after,
         name: '変更後のノード名1',
         display_value: '2千人（変更後）',
         is_value_locked: true,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: true
       )
 
-      child_node2_svg_after = find('g > text', text: '変更後のノード名2').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node2_svg_after,
         name: '変更後のノード名2',
         display_value: '4000円（変更後）',
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: true
       )
     end
 
@@ -120,31 +114,28 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: false
       )
 
-      child_node1_svg_after = find('g > text', text: '子1').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_svg_after,
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
-        operation: 'add'
+        operation: 'add',
+        is_leaf: true
       )
 
-      child_node2_svg_after = find('g > text', text: '子2').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node2_svg_after,
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
-        operation: ''
+        operation: '',
+        is_leaf: true
       )
     end
 
@@ -185,30 +176,27 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: false
       )
-      child_node1_svg_after = find('g > text', text: '子1\'').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_svg_after,
         name: '子1\'',
         display_value: '2千人（変更後）',
         is_value_locked: true,
-        operation: 'add'
+        operation: 'add',
+        is_leaf: true
       )
 
-      child_node2_svg_after = find('g > text', text: '子2\'').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node2_svg_after,
         name: '子2\'',
         display_value: '4000円（変更後）',
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: true
       )
 
       find('g > text', text: '子2\'').ancestor('g.rd3t-leaf-node').click
@@ -231,29 +219,26 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート\'',
         display_value: '500千円\'',
         is_value_locked: false,
-        operation: ''
+        operation: '',
+        is_leaf: false
       )
-      child_node1_svg_after = find('g > text', text: '子1').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_svg_after,
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: true
       )
-      child_node2_svg_after = find('g > text', text: '子2').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node2_svg_after,
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
-        operation: ''
+        operation: '',
+        is_leaf: true
       )
     end
 
@@ -265,13 +250,12 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      child_node1_first = find('g > text', text: '子1\'').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_first,
         name: '子1\'',
         display_value: '4千人',
         is_value_locked: false,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: true
       )
 
       # 編集と更新（2回目）
@@ -282,13 +266,12 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      child_node1_second = find('g > text', text: '子1\'\'').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_second,
         name: '子1\'\'',
         display_value: '1.5万人',
         is_value_locked: false,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: true
       )
 
       # 編集と更新（3回目）
@@ -299,13 +282,12 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      child_node1_third = find('g > text', text: '子1\'\'\'').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: child_node1_third,
         name: '子1\'\'\'',
         display_value: '2500.1人',
         is_value_locked: false,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: true
       )
     end
 
@@ -350,21 +332,19 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 選択したノードの更新に基づいて親ノードの値も更新されていること、さらにその親ノードはisValueLocked: true なので、値は変わらないことを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート',
         display_value: '1000万円', # isValueLocked: true なので、値は変わらない
         is_value_locked: true,
-        operation: ''
+        operation: '',
+        is_leaf: false
       )
-      child_node1_svg_after = find('g > text', text: '子1').ancestor('g.rd3t-node')
       expect_node_display(
-        node_svg: child_node1_svg_after,
         name: '子1',
         display_value: '14500人', # 1万 + 2500 + 2000 に更新される
         is_value_locked: false,
-        operation: 'multiply'
+        operation: 'multiply',
+        is_leaf: false
       )
     end
   end
@@ -392,21 +372,152 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      root_node_svg_after = find('g > text', text: 'ルート').ancestor('g.rd3t-leaf-node')
       expect_node_display(
-        node_svg: root_node_svg_after,
         name: 'ルート\'',
         display_value: '500千円\'',
         is_value_locked: false,
-        operation: ''
+        operation: '',
+        is_leaf: true
+      )
+    end
+  end
+
+  describe('選択した階層にノードを追加') do
+    before do
+      # データの作成
+      tree = create(:tree, user: User.find_by(uid: '1234'))
+      root_node = create(:node, tree:, name: 'ルート', value: 1000, value_format: '万', unit: '円', is_value_locked: true)
+      create(:node, tree:, name: '子1', value: 5000, value_format: 'なし', unit: '人', is_value_locked: false,
+                    parent: root_node)
+      create(:node, tree:, name: '子2', value: 2000, value_format: 'なし', unit: '円', is_value_locked: false,
+                    parent: root_node)
+      create(:layer, tree:, operation: 'multiply', fraction: 0, parent_node: root_node)
+
+      # ツリー編集画面を表示し、ノードをクリックしてツールエリアを開く
+      visit edit_tree_path(tree)
+      find('g > text', text: '子1').ancestor('g.rd3t-leaf-node').click
+    end
+
+    it('要素を追加ボタンを押すと、新しい要素のエリアが表示される。') do
+      click_button '要素を追加'
+      expect(page).to have_selector('#node-detail-3')
+      expect(page).to have_content('要素3')
+      expect(page).to have_selector('#node-detail-3 input[name="name"][value="要素3"]')
+      expect(page).to have_selector('#node-detail-3 input[name="value"][value="1"]')
+      expect(page).to have_selector('#node-detail-3 input[name="unit"][value=""]')
+      expect(page).to have_select('node-3-valueFormat', selected: 'なし')
+      expect(page).to have_selector('#node-detail-3 input[name="isValueLocked"][type="checkbox"]:not(:checked)')
+    end
+
+    it('追加された要素のデフォルトの数値値が、階層内の要素間の関係ごとに設定されている。') do
+      expect(page).to have_button('かけ算', class: 'bg-base-100 border border-neutral')
+      click_button '要素を追加'
+      expect(page).to have_selector('#node-detail-3 input[name="value"][value="1"]')
+      click_button 'たし算'
+      click_button '要素を追加'
+      expect(page).to have_selector('#node-detail-4 input[name="value"][value="0"]')
+    end
+
+    it('要素を追加ボタンを押すと、計算式に要素が追加されている。') do
+      click_button '要素を追加'
+      within('#calc-member-2') do
+        expect(page).to have_text('要素3')
+        expect(page).to have_text('1')
+      end
+    end
+
+    it('要素を追加ボタンを押しても、ツリーの表示はまだ変わらない。') do
+      click_button '要素を追加'
+      expect(page).not_to have_selector('g > text', text: '要素3')
+      expect(page).to have_selector('g > text', text: '子1')
+    end
+
+    it('要素を追加ボタンを押して、更新ボタン→更新するを押すと、ツリーに要素が追加される。') do
+      click_button '要素を追加'
+      find('#updateButton label', text: '更新').click
+      find('.modal-action label', text: '更新する').click
+      expect_node_display(
+        name: '子1',
+        display_value: '5000人',
+        is_value_locked: false,
+        operation: 'multiply',
+        is_leaf: true
+      )
+      expect_node_display(
+        name: '子2',
+        display_value: '2000円',
+        is_value_locked: false,
+        operation: 'multiply',
+        is_leaf: true
+      )
+      expect_node_display(
+        name: '要素3',
+        display_value: '1',
+        is_value_locked: false,
+        operation: '',
+        is_leaf: true
+      )
+    end
+
+    it('要素を追加ボタンを押して、追加した要素と既存の要素のプロパティを編集し、更新ボタン→更新するを押すと、ツリーにすべての編集内容が反映される。') do
+      click_button '要素を追加'
+      node_detail1 = find_by_id('node-detail-1')
+      node_detail1.find('input[name="name"]').set('変更後のノード名1')
+      node_detail1.find('input[name="unit"]').set('人（変更後）')
+      node_detail1.find('input[name="value"]').set(2)
+      node_detail1.find('select[name="valueFormat"]').select('千')
+      node_detail1.find('input[name="isValueLocked"]').set(true)
+
+      node_detail2 = find_by_id('node-detail-2')
+      node_detail2.find('input[name="name"]').set('変更後のノード名2')
+      node_detail2.find('input[name="unit"]').set('円（変更後）')
+      node_detail2.find('input[name="value"]').set(4000)
+      node_detail2.find('select[name="valueFormat"]').select('なし')
+      node_detail2.find('input[name="isValueLocked"]').set(true)
+
+      node_detail3 = find_by_id('node-detail-3')
+      node_detail3.find('input[name="name"]').set('変更後のノード名3')
+      node_detail3.find('input[name="unit"]').set('円')
+      node_detail3.find('input[name="value"]').set(0.1)
+      node_detail3.find('select[name="valueFormat"]').select('千')
+      node_detail3.find('input[name="isValueLocked"]').set(true)
+
+      find('#updateButton label', text: '更新').click
+      find('.modal-action label', text: '更新する').click
+
+      expect_node_display(
+        name: '変更後のノード名1',
+        display_value: '2千人（変更後）',
+        is_value_locked: true,
+        operation: 'multiply',
+        is_leaf: true
+      )
+      expect_node_display(
+        name: '変更後のノード名2',
+        display_value: '4000円（変更後）',
+        is_value_locked: true,
+        operation: 'multiply',
+        is_leaf: true
+      )
+      expect_node_display(
+        name: '変更後のノード名3',
+        display_value: '0.1千円',
+        is_value_locked: true,
+        operation: '',
+        is_leaf: true
       )
     end
   end
 end
 
-def expect_node_display(node_svg:, name:, display_value:, is_value_locked:, operation: nil)
-  expect(node_svg).to have_text(name).and have_text(display_value)
-  if is_value_locked == true
+def expect_node_display(name:, display_value:, is_value_locked:, is_leaf:, operation: nil)
+  node_svg = if is_leaf
+               find('g > text', text: name).ancestor('g.rd3t-leaf-node')
+             else
+               find('g > text', text: name).ancestor('g.rd3t-node')
+             end
+  expect(node_svg).to have_text(display_value)
+  if is_value_locked
     expect(node_svg).to have_css('svg.fa-lock')
   else
     expect(node_svg).not_to have_css('svg.fa-lock')


### PR DESCRIPTION
close #164 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/164

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

「要素を追加」ボタンを押したらlayerProperty.selectedNodeに新しいノードのオブジェクトを追加し、更新実行するとDBに保存されるようにした。
システムテストを追加した。

上記にともなって
- idがoptionalになるNode, Layerの型を定義
- Calculationの表示の並び順idを使っていて、idが参照できないエラーになっていたのでidではなくindexを参照するように修正

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する（localhostでなく127.0.0.1 だとGoogleログインができないので注意）
3. Googleアカウントでログインしたユーザーでツリーを作成 or 既存のツリーのユーザーをログインしたユーザーに変更する
4. ツリー編集画面にアクセスし、任意の要素をクリックしてツールエリアを開く
5. 「要素を追加」ボタンをクリック
6. 更新ボタンをクリック
7. 要素が追加されていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

ツールエリアを開いた状態から「要素を追加」ボタンをクリックしても何も起きない

![スクリーンショット 2023-08-18 11 51 42](https://github.com/peno022/kpi-tree-generator/assets/40317050/7cfa0f7f-671e-46ca-a189-ac5694268fab)

### 変更後

「要素を追加」ボタンをクリックすると新しい要素をツールエリアに表示する

![スクリーンショット 2023-08-18 11 51 59](https://github.com/peno022/kpi-tree-generator/assets/40317050/e54db3a9-2899-41ef-8707-3222ea95e7d6)

更新を実行するとツリーに反映される

![スクリーンショット 2023-08-18 11 52 11](https://github.com/peno022/kpi-tree-generator/assets/40317050/795c47aa-f59e-4cd6-b618-1d0f7f360433)