### PR TITLE
別な階層を選択してもノード詳細が更新されない問題の解消、バリデーションロジックの修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,10 @@ Metrics/MethodLength:
   Exclude:
     - spec/**/*
 
+Metrics/ParameterLists:
+  Exclude:
+    - spec/**/*
+
 ### RSpec
 
 # 1つのテストケースあたりの行数

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -8,7 +8,6 @@ import OpenModalButton from "@/components/shared/OpenModalButton";
 import propagateSelectedNodesChangesToTree from "@/propagateSelectedNodesChangesToTree";
 import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
-import useValidationLogic from "@/hooks/useValidationLogic";
 import useLayerToolLogic from "@/hooks/useLayerToolLogic";
 
 type LayerToolProps = {
@@ -31,18 +30,6 @@ const LayerTool: React.FC<LayerToolProps> = ({
   );
 
   const {
-    setNodeValidationResults,
-    handleNodeValidationResultsChange,
-    fractionValidation,
-    setFractionValidation,
-    fractionErrorMessage,
-    setFractionErrorMessage,
-    useUpdateButtonStatus,
-  } = useValidationLogic(selectedNodes.length);
-
-  const isUpdateButtonDisabled = useUpdateButtonStatus();
-
-  const {
     layerProperty,
     setlayerProperty,
     addNode,
@@ -51,13 +38,17 @@ const LayerTool: React.FC<LayerToolProps> = ({
     handleFractionChange,
     inputFraction,
     setInputFraction,
-  } = useLayerToolLogic(
-    selectedNodes,
-    selectedLayer,
-    parentNode,
-    setFractionValidation,
-    setFractionErrorMessage
-  );
+    fieldValidationResults,
+    fieldValidationErrors,
+    fractionValidation,
+    fractionErrorMessage,
+    useUpdateButtonStatus,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange,
+    resetValidationResults,
+  } = useLayerToolLogic(selectedNodes, selectedLayer, parentNode);
+
+  const isUpdateButtonDisabled = useUpdateButtonStatus();
 
   useEffect(() => {
     setlayerProperty({
@@ -65,9 +56,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
       layer: selectedLayer,
     });
     setInputFraction(selectedLayer.fraction.toString());
-    setFractionValidation(true);
-    setNodeValidationResults(Array(selectedNodes.length).fill(true));
-    setFractionErrorMessage(null);
+    resetValidationResults(selectedNodes.length);
     setErrorMessage(null);
   }, [selectedNodes, selectedLayer, parentNode]);
 
@@ -127,7 +116,14 @@ const LayerTool: React.FC<LayerToolProps> = ({
               index={index}
               node={node}
               handleNodeInfoChange={handleNodeInfoChange}
-              setNodeValidationResult={handleNodeValidationResultsChange}
+              fieldValidationResults={fieldValidationResults[index]}
+              fieldValidationErrors={fieldValidationErrors[index]}
+              handleFieldValidationResultsChange={
+                handleFieldValidationResultsChange
+              }
+              handleFieldValidationErrorsChange={
+                handleFieldValidationErrorsChange
+              }
             />
           ))}
           <div className="flex justify-center">

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -9,6 +9,7 @@ import propagateSelectedNodesChangesToTree from "@/propagateSelectedNodesChanges
 import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
 import useLayerToolLogic from "@/hooks/useLayerToolLogic";
+import useUpdateButtonStatus from "@/hooks/useUpdateButtonStatus";
 
 type LayerToolProps = {
   selectedNodes: NodeFromApi[];
@@ -42,13 +43,16 @@ const LayerTool: React.FC<LayerToolProps> = ({
     fieldValidationErrors,
     fractionValidation,
     fractionErrorMessage,
-    useUpdateButtonStatus,
     handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
     resetValidationResults,
   } = useLayerToolLogic(selectedNodes, selectedLayer, parentNode);
 
-  const isUpdateButtonDisabled = useUpdateButtonStatus();
+  const isUpdateButtonDisabled = useUpdateButtonStatus(
+    fieldValidationResults,
+    false,
+    fractionValidation
+  );
 
   useEffect(() => {
     setlayerProperty({

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import NodeDetail from "@/components/trees/tool/nodeDetailArea/NodeDetail";
-import { Node, Layer, NodeFromApi, TreeDataFromApi } from "@/types";
+import { Layer, NodeFromApi, TreeDataFromApi } from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
 import Operations from "@/components/trees/tool/operationArea/Operations";
 import Calculation from "@/components/trees/tool/calculationArea/Calculation";
@@ -8,6 +8,8 @@ import OpenModalButton from "@/components/shared/OpenModalButton";
 import propagateSelectedNodesChangesToTree from "@/propagateSelectedNodesChangesToTree";
 import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
+import useValidationLogic from "@/hooks/useValidationLogic";
+import useLayerToolLogic from "@/hooks/useLayerToolLogic";
 
 type LayerToolProps = {
   selectedNodes: NodeFromApi[];
@@ -15,11 +17,6 @@ type LayerToolProps = {
   parentNode: NodeFromApi;
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
   treeData: TreeDataFromApi;
-};
-
-export type LayerToolState = {
-  nodes: Node[];
-  layer: Layer;
 };
 
 const LayerTool: React.FC<LayerToolProps> = ({
@@ -32,25 +29,35 @@ const LayerTool: React.FC<LayerToolProps> = ({
   const { errorMessage, sendUpdateRequest, setErrorMessage } = useTreeUpdate(
     treeData.tree.id
   );
-  const [layerProperty, setlayerProperty] = useState<LayerToolState>({
-    nodes: selectedNodes,
-    layer: selectedLayer,
-  });
-  const [inputFraction, setInputFraction] = useState<string>(
-    selectedLayer.fraction.toString()
-  );
-  const [nodeValidationResults, setNodeValidationResults] = useState<boolean[]>(
-    Array(selectedNodes.length).fill(true)
-  );
-  const [fractionValidation, setFractionValidation] = useState(true);
-  const [fractionErrorMessage, setFractionErrorMessage] = useState<
-    string | null
-  >(null);
-  const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(true);
 
-  const isAllValid = (results: boolean[]): boolean => {
-    return results.every((result) => result);
-  };
+  const {
+    setNodeValidationResults,
+    handleNodeValidationResultsChange,
+    fractionValidation,
+    setFractionValidation,
+    fractionErrorMessage,
+    setFractionErrorMessage,
+    useUpdateButtonStatus,
+  } = useValidationLogic(selectedNodes.length);
+
+  const isUpdateButtonDisabled = useUpdateButtonStatus();
+
+  const {
+    layerProperty,
+    setlayerProperty,
+    addNode,
+    handleNodeInfoChange,
+    handleOperationChange,
+    handleFractionChange,
+    inputFraction,
+    setInputFraction,
+  } = useLayerToolLogic(
+    selectedNodes,
+    selectedLayer,
+    parentNode,
+    setFractionValidation,
+    setFractionErrorMessage
+  );
 
   useEffect(() => {
     setlayerProperty({
@@ -63,85 +70,6 @@ const LayerTool: React.FC<LayerToolProps> = ({
     setFractionErrorMessage(null);
     setErrorMessage(null);
   }, [selectedNodes, selectedLayer, parentNode]);
-
-  useEffect(() => {
-    setIsUpdateButtonDisabled(
-      !isAllValid(nodeValidationResults) || !fractionValidation
-    );
-  }, [nodeValidationResults, fractionValidation]);
-
-  const handleNodeInfoChange = (index: number, newNodeInfo: Node) => {
-    const newValues = [...layerProperty.nodes];
-    newValues[index] = newNodeInfo;
-    setlayerProperty({
-      ...layerProperty,
-      nodes: newValues,
-    });
-  };
-
-  const handleNodeValidationResultsChange = (
-    index: number,
-    isValid: boolean
-  ) => {
-    const newValues = [...nodeValidationResults];
-    newValues[index] = isValid;
-    setNodeValidationResults(newValues);
-  };
-
-  const handleOperationChange = (operation: "multiply" | "add") => {
-    const newLayerValues = { ...layerProperty.layer };
-    newLayerValues.operation = operation;
-    setlayerProperty({
-      ...layerProperty,
-      layer: newLayerValues,
-    });
-  };
-
-  const handleFractionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const inputFraction = e.target.value;
-    const newLayerValues = { ...layerProperty.layer };
-    setInputFraction(inputFraction);
-    const numericValue = Number(inputFraction);
-    if (isNaN(numericValue)) {
-      setFractionValidation(false);
-      setFractionErrorMessage("数値を入力してください");
-      newLayerValues.fraction = 0;
-      setlayerProperty({
-        ...layerProperty,
-        layer: newLayerValues,
-      });
-      return;
-    }
-    newLayerValues.fraction = numericValue;
-    setFractionValidation(true);
-    setFractionErrorMessage(null);
-    setlayerProperty({
-      ...layerProperty,
-      layer: newLayerValues,
-    });
-  };
-
-  const addNode = () => {
-    const newNodes = [...layerProperty.nodes];
-    let initialValue: number;
-    if (layerProperty.layer.operation === "multiply") {
-      initialValue = 1;
-    } else {
-      initialValue = 0;
-    }
-    newNodes.push({
-      name: `要素${newNodes.length + 1}`,
-      value: initialValue,
-      unit: "",
-      valueFormat: "なし",
-      isValueLocked: false,
-      parentId: parentNode.id,
-    });
-    setlayerProperty({
-      ...layerProperty,
-      nodes: newNodes,
-    });
-  };
 
   const saveLayerProperty = async () => {
     const result = await sendUpdateRequest(

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -54,7 +54,6 @@ const LayerTool: React.FC<LayerToolProps> = ({
 
   useEffect(() => {
     setlayerProperty({
-      ...layerProperty,
       nodes: selectedNodes,
       layer: selectedLayer,
     });

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -39,17 +39,15 @@ const LayerTool: React.FC<LayerToolProps> = ({
     handleFractionChange,
     inputFraction,
     setInputFraction,
-    fieldValidationResults,
     fieldValidationErrors,
     fractionValidation,
     fractionErrorMessage,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
     resetValidationResults,
   } = useLayerToolLogic(selectedNodes, selectedLayer, parentNode);
 
   const isUpdateButtonDisabled = useUpdateButtonStatus(
-    fieldValidationResults,
+    fieldValidationErrors,
     false,
     fractionValidation
   );
@@ -120,11 +118,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
               index={index}
               node={node}
               handleNodeInfoChange={handleNodeInfoChange}
-              fieldValidationResults={fieldValidationResults[index]}
               fieldValidationErrors={fieldValidationErrors[index]}
-              handleFieldValidationResultsChange={
-                handleFieldValidationResultsChange
-              }
               handleFieldValidationErrorsChange={
                 handleFieldValidationErrorsChange
               }

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import NodeDetail from "@/components/trees/tool/nodeDetailArea/NodeDetail";
 import OpenModalButton from "@/components/shared/OpenModalButton";
-import { Node, NodeFromApi, TreeDataFromApi, TreeData } from "@/types";
+import { NodeFromApi, TreeDataFromApi } from "@/types";
 import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
+import useRootNodeToolLogic from "@/hooks/useRootNodeToolLogic";
+import useUpdateButtonStatus from "@/hooks/useUpdateButtonStatus";
 
 type RootNodeToolProps = {
   selectedRootNode: NodeFromApi;
@@ -19,17 +21,20 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
   const { errorMessage, sendUpdateRequest, setErrorMessage } = useTreeUpdate(
     treeData.tree.id
   );
-  const [nodeInfo, setNodeInfo] = useState<Node>(selectedRootNode);
-  const [validatinResult, setValidationResult] = useState<boolean>(true);
-  const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(true);
 
-  useEffect(() => {
-    setIsUpdateButtonDisabled(!validatinResult);
-  }, [validatinResult]);
+  const {
+    nodeInfo,
+    handleNodeInfoChange,
+    fieldValidationResults,
+    fieldValidationErrors,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange,
+  } = useRootNodeToolLogic(selectedRootNode);
 
-  const handleNodeInfoChange = (_index = 0, updatedNodeInfo: Node) => {
-    setNodeInfo(updatedNodeInfo);
-  };
+  const isUpdateButtonDisabled = useUpdateButtonStatus(
+    fieldValidationResults,
+    true
+  );
 
   const saveNodeInfo = async () => {
     setErrorMessage(null);
@@ -55,10 +60,6 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
     }
   };
 
-  const handleNodeValidationResultChange = (_index = 0, isValid: boolean) => {
-    setValidationResult(isValid);
-  };
-
   return (
     <>
       <div className="relative flex flex-col h-full">
@@ -68,7 +69,14 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
             index={0}
             node={nodeInfo}
             handleNodeInfoChange={handleNodeInfoChange}
-            setNodeValidationResult={handleNodeValidationResultChange}
+            fieldValidationResults={fieldValidationResults[0]}
+            fieldValidationErrors={fieldValidationErrors[0]}
+            handleFieldValidationResultsChange={
+              handleFieldValidationResultsChange
+            }
+            handleFieldValidationErrorsChange={
+              handleFieldValidationErrorsChange
+            }
           />
         </div>
         <div

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -25,14 +25,12 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
   const {
     nodeInfo,
     handleNodeInfoChange,
-    fieldValidationResults,
     fieldValidationErrors,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
   } = useRootNodeToolLogic(selectedRootNode);
 
   const isUpdateButtonDisabled = useUpdateButtonStatus(
-    fieldValidationResults,
+    fieldValidationErrors,
     true
   );
 
@@ -69,11 +67,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
             index={0}
             node={nodeInfo}
             handleNodeInfoChange={handleNodeInfoChange}
-            fieldValidationResults={fieldValidationResults[0]}
             fieldValidationErrors={fieldValidationErrors[0]}
-            handleFieldValidationResultsChange={
-              handleFieldValidationResultsChange
-            }
             handleFieldValidationErrorsChange={
               handleFieldValidationErrorsChange
             }

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import NodeField from "@/components/trees/tool/nodeDetailArea/NodeField";
 import { Node } from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
+import useNodeDetailLogic from "@/hooks/useNodeDetailLogic";
 
 export type NodeDetailProps = {
   index: number;
@@ -9,156 +10,19 @@ export type NodeDetailProps = {
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
   setNodeValidationResult: (index: number, isValid: boolean) => void;
 };
-export interface FieldValidationResults {
-  name: boolean;
-  unit: boolean;
-  value: boolean;
-  valueFormat: boolean;
-  isValueLocked: boolean;
-}
-
-export interface validationErrors {
-  name: string;
-  unit: string;
-  value: string;
-  valueFormat: string;
-  isValueLocked: string;
-}
-
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,
   node,
   handleNodeInfoChange,
   setNodeValidationResult,
 }) => {
-  const [fieldValidationResults, setFieldValidationResults] =
-    useState<FieldValidationResults>({
-      name: true,
-      unit: true,
-      value: true,
-      valueFormat: true,
-      isValueLocked: true,
-    });
-
-  const [errors, setErrors] = useState<validationErrors>({
-    name: "",
-    unit: "",
-    value: "",
-    valueFormat: "",
-    isValueLocked: "",
-  });
-
-  useEffect(() => {
-    setNodeValidationResult(
+  const { fieldValidationResults, fieldValidationErrors, handleInputChange } =
+    useNodeDetailLogic(
       index,
-      Object.values(fieldValidationResults).every((result) => result)
+      node,
+      handleNodeInfoChange,
+      setNodeValidationResult
     );
-  }, [fieldValidationResults]);
-
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
-  ) => {
-    const name = e.target.name;
-    let value: string | number | boolean;
-    if (e.target instanceof HTMLInputElement) {
-      value =
-        e.target.type === "checkbox" ? e.target.checked : e.target.value.trim();
-    } else {
-      value = e.target.value.trim();
-    }
-    const updatedNodeInfo = { ...node, [name]: value };
-    handleNodeInfoChange(index, updatedNodeInfo);
-    // バリデーションチェック
-    if (name === "name" || name === "value") {
-      if (value === null || value === "") {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          [name]: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          [name]: "必須項目です",
-        }));
-        return;
-      }
-    }
-    if (name === "value") {
-      if (isNaN(Number(value))) {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          [name]: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          [name]: "数値を入力してください",
-        }));
-        return;
-      }
-    }
-
-    if (name === "valueFormat") {
-      if (value === "%" && updatedNodeInfo.unit !== "") {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: false,
-          valueFormat: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "％表示のときは単位を空にしてください",
-          valueFormat: "％表示のときは単位を空にしてください",
-        }));
-        return;
-      } else {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: true,
-          valueFormat: true,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "",
-          valueFormat: "",
-        }));
-      }
-    }
-
-    if (name === "unit") {
-      if (value !== "" && updatedNodeInfo.valueFormat === "%") {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: false,
-          valueFormat: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "％表示のときは単位を空にしてください",
-          valueFormat: "％表示のときは単位を空にしてください",
-        }));
-        return;
-      } else {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: true,
-          valueFormat: true,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "",
-          valueFormat: "",
-        }));
-      }
-    }
-
-    setFieldValidationResults((prev) => ({
-      ...prev,
-      [name]: true,
-    }));
-    setErrors((prev) => ({
-      ...prev,
-      [name]: "",
-    }));
-  };
 
   return (
     <div className="relative">
@@ -187,7 +51,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             value={node.name}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationResults.name}
-            errorMessage={errors.name}
+            errorMessage={fieldValidationErrors.name}
             index={index + 1}
           />
           <NodeField
@@ -197,7 +61,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             value={node.unit}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationResults.unit}
-            errorMessage={errors.unit}
+            errorMessage={fieldValidationErrors.unit}
             index={index + 1}
           />
         </div>
@@ -209,7 +73,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             value={node.value}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationResults.value}
-            errorMessage={errors.value}
+            errorMessage={fieldValidationErrors.value}
             index={index + 1}
           />
           <NodeField
@@ -219,7 +83,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             value={node.valueFormat}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationResults.valueFormat}
-            errorMessage={errors.valueFormat}
+            errorMessage={fieldValidationErrors.valueFormat}
             index={index + 1}
           />
           <div className="ml-8">
@@ -230,7 +94,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
               checked={node.isValueLocked}
               handleInputChange={handleInputChange}
               isValidField={fieldValidationResults.isValueLocked}
-              errorMessage={errors.isValueLocked}
+              errorMessage={fieldValidationErrors.isValueLocked}
               index={index + 1}
             />
           </div>

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import NodeField from "@/components/trees/tool/nodeDetailArea/NodeField";
-import { Node } from "@/types";
+import { Node, FieldValidationResults, FieldValidationErrors } from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
 import useNodeDetailLogic from "@/hooks/useNodeDetailLogic";
 
@@ -8,21 +8,35 @@ export type NodeDetailProps = {
   index: number;
   node: Node;
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
-  setNodeValidationResult: (index: number, isValid: boolean) => void;
+  fieldValidationResults: FieldValidationResults;
+  fieldValidationErrors: FieldValidationErrors;
+  handleFieldValidationResultsChange: (
+    index: number,
+    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
+    isValid: boolean
+  ) => void;
+  handleFieldValidationErrorsChange: (
+    index: number,
+    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
+    errorMessage: string
+  ) => void;
 };
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,
   node,
   handleNodeInfoChange,
-  setNodeValidationResult,
+  fieldValidationResults,
+  fieldValidationErrors,
+  handleFieldValidationResultsChange,
+  handleFieldValidationErrorsChange,
 }) => {
-  const { fieldValidationResults, fieldValidationErrors, handleInputChange } =
-    useNodeDetailLogic(
-      index,
-      node,
-      handleNodeInfoChange,
-      setNodeValidationResult
-    );
+  const { handleInputChange } = useNodeDetailLogic(
+    index,
+    node,
+    handleNodeInfoChange,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange
+  );
 
   return (
     <div className="relative">

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import NodeField from "@/components/trees/tool/nodeDetailArea/NodeField";
-import { Node, FieldValidationResults, FieldValidationErrors } from "@/types";
+import {
+  Node,
+  FieldValidationResults,
+  FieldValidationErrors,
+  FieldValidationError,
+} from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
 import useNodeDetailLogic from "@/hooks/useNodeDetailLogic";
 
@@ -15,11 +20,7 @@ export type NodeDetailProps = {
     fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
     isValid: boolean
   ) => void;
-  handleFieldValidationErrorsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    errorMessage: string
-  ) => void;
+  handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void;
 };
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import NodeField from "@/components/trees/tool/nodeDetailArea/NodeField";
-import {
-  Node,
-  FieldValidationResults,
-  FieldValidationErrors,
-  FieldValidationError,
-} from "@/types";
+import { Node, FieldValidationErrors, FieldValidationError } from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
 import useNodeDetailLogic from "@/hooks/useNodeDetailLogic";
 
@@ -13,29 +8,20 @@ export type NodeDetailProps = {
   index: number;
   node: Node;
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
-  fieldValidationResults: FieldValidationResults;
   fieldValidationErrors: FieldValidationErrors;
-  handleFieldValidationResultsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    isValid: boolean
-  ) => void;
   handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void;
 };
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,
   node,
   handleNodeInfoChange,
-  fieldValidationResults,
   fieldValidationErrors,
-  handleFieldValidationResultsChange,
   handleFieldValidationErrorsChange,
 }) => {
   const { handleInputChange } = useNodeDetailLogic(
     index,
     node,
     handleNodeInfoChange,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange
   );
 
@@ -65,7 +51,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             label="名前"
             value={node.name}
             handleInputChange={handleInputChange}
-            isValidField={fieldValidationResults.name}
+            isValidField={fieldValidationErrors.name === ""}
             errorMessage={fieldValidationErrors.name}
             index={index + 1}
           />
@@ -75,7 +61,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             label="単位"
             value={node.unit}
             handleInputChange={handleInputChange}
-            isValidField={fieldValidationResults.unit}
+            isValidField={fieldValidationErrors.unit === ""}
             errorMessage={fieldValidationErrors.unit}
             index={index + 1}
           />
@@ -87,7 +73,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             label="数値"
             value={node.value}
             handleInputChange={handleInputChange}
-            isValidField={fieldValidationResults.value}
+            isValidField={fieldValidationErrors.value === ""}
             errorMessage={fieldValidationErrors.value}
             index={index + 1}
           />
@@ -97,7 +83,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             label="表示形式"
             value={node.valueFormat}
             handleInputChange={handleInputChange}
-            isValidField={fieldValidationResults.valueFormat}
+            isValidField={fieldValidationErrors.valueFormat === ""}
             errorMessage={fieldValidationErrors.valueFormat}
             index={index + 1}
           />
@@ -108,7 +94,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
               label="数値を自動更新しない"
               checked={node.isValueLocked}
               handleInputChange={handleInputChange}
-              isValidField={fieldValidationResults.isValueLocked}
+              isValidField={fieldValidationErrors.isValueLocked === ""}
               errorMessage={fieldValidationErrors.isValueLocked}
               index={index + 1}
             />

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeField.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeField.tsx
@@ -36,7 +36,7 @@ const NodeField: React.FC<Props> = ({
           name={name}
           onChange={handleInputChange}
           className={isValidField ? "checkbox" : "checkbox checkbox-error"}
-          defaultChecked={checked}
+          checked={checked}
           id={`node-${index}-${name}`}
         />
       );
@@ -55,7 +55,7 @@ const NodeField: React.FC<Props> = ({
           onChange={handleInputChange}
           placeholder={placeholder}
           className={inputClass}
-          defaultValue={value}
+          value={value}
           required
           id={`node-${index}-${name}`}
         />
@@ -72,7 +72,7 @@ const NodeField: React.FC<Props> = ({
           name={name}
           onChange={handleInputChange}
           className={selectClass}
-          defaultValue={value}
+          value={value}
           id={`node-${index}-${name}`}
         >
           <option>なし</option>

--- a/app/javascript/hooks/useFieldValidation.ts
+++ b/app/javascript/hooks/useFieldValidation.ts
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { FieldValidationResults, FieldValidationErrors } from "@/types";
+
+const useFieldValidation = (initialNodesLength: number) => {
+  const [fieldValidationResults, setFieldValidationResults] = useState<
+    FieldValidationResults[]
+  >(
+    Array(initialNodesLength).fill({
+      name: true,
+      unit: true,
+      value: true,
+      valueFormat: true,
+      isValueLocked: true,
+    })
+  );
+
+  const [fieldValidationErrors, setFieldValidationErrors] = useState<
+    FieldValidationErrors[]
+  >(
+    Array(initialNodesLength).fill({
+      name: "",
+      unit: "",
+      value: "",
+      valueFormat: "",
+      isValueLocked: "",
+    })
+  );
+  const handleFieldValidationResultsChange: (
+    index: number,
+    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
+    isValid: boolean
+  ) => void = (index, fieldName, isValid) => {
+    const newResults = [...fieldValidationResults];
+    newResults[index] = { ...newResults[index], [fieldName]: isValid };
+    setFieldValidationResults(newResults);
+  };
+
+  const handleFieldValidationErrorsChange: (
+    index: number,
+    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
+    errorMessage: string
+  ) => void = (index, fieldName, errorMessage) => {
+    const newFieldValidationErrors = [...fieldValidationErrors];
+    newFieldValidationErrors[index] = {
+      ...newFieldValidationErrors[index],
+      [fieldName]: errorMessage,
+    };
+    setFieldValidationErrors(newFieldValidationErrors);
+  };
+
+  return {
+    fieldValidationResults,
+    fieldValidationErrors,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange,
+    setFieldValidationErrors,
+    setFieldValidationResults,
+  };
+};
+
+export default useFieldValidation;

--- a/app/javascript/hooks/useFieldValidation.ts
+++ b/app/javascript/hooks/useFieldValidation.ts
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { FieldValidationResults, FieldValidationErrors } from "@/types";
+import {
+  FieldValidationResults,
+  FieldValidationErrors,
+  FieldValidationError,
+} from "@/types";
 
 const useFieldValidation = (initialNodesLength: number) => {
   const [fieldValidationResults, setFieldValidationResults] = useState<
@@ -36,15 +40,16 @@ const useFieldValidation = (initialNodesLength: number) => {
   };
 
   const handleFieldValidationErrorsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    errorMessage: string
-  ) => void = (index, fieldName, errorMessage) => {
+    errors: FieldValidationError[]
+  ) => void = (errors) => {
     const newFieldValidationErrors = [...fieldValidationErrors];
-    newFieldValidationErrors[index] = {
-      ...newFieldValidationErrors[index],
-      [fieldName]: errorMessage,
-    };
+    errors.forEach((error: FieldValidationError) => {
+      const { index, fieldName, errorMessage } = error;
+      newFieldValidationErrors[index] = {
+        ...newFieldValidationErrors[index],
+        [fieldName]: errorMessage,
+      };
+    });
     setFieldValidationErrors(newFieldValidationErrors);
   };
 

--- a/app/javascript/hooks/useFieldValidation.ts
+++ b/app/javascript/hooks/useFieldValidation.ts
@@ -1,23 +1,7 @@
 import { useState } from "react";
-import {
-  FieldValidationResults,
-  FieldValidationErrors,
-  FieldValidationError,
-} from "@/types";
+import { FieldValidationErrors, FieldValidationError } from "@/types";
 
 const useFieldValidation = (initialNodesLength: number) => {
-  const [fieldValidationResults, setFieldValidationResults] = useState<
-    FieldValidationResults[]
-  >(
-    Array(initialNodesLength).fill({
-      name: true,
-      unit: true,
-      value: true,
-      valueFormat: true,
-      isValueLocked: true,
-    })
-  );
-
   const [fieldValidationErrors, setFieldValidationErrors] = useState<
     FieldValidationErrors[]
   >(
@@ -29,15 +13,6 @@ const useFieldValidation = (initialNodesLength: number) => {
       isValueLocked: "",
     })
   );
-  const handleFieldValidationResultsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    isValid: boolean
-  ) => void = (index, fieldName, isValid) => {
-    const newResults = [...fieldValidationResults];
-    newResults[index] = { ...newResults[index], [fieldName]: isValid };
-    setFieldValidationResults(newResults);
-  };
 
   const handleFieldValidationErrorsChange: (
     errors: FieldValidationError[]
@@ -54,12 +29,9 @@ const useFieldValidation = (initialNodesLength: number) => {
   };
 
   return {
-    fieldValidationResults,
     fieldValidationErrors,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
     setFieldValidationErrors,
-    setFieldValidationResults,
   };
 };
 

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -1,11 +1,6 @@
-import { useState, useEffect } from "react";
-import {
-  Node,
-  Layer,
-  NodeFromApi,
-  FieldValidationResults,
-  FieldValidationErrors,
-} from "@/types";
+import { useState } from "react";
+import useFieldValidation from "@/hooks/useFieldValidation";
+import { Node, Layer, NodeFromApi } from "@/types";
 
 const useLayerToolLogic = (
   selectedNodes: NodeFromApi[],
@@ -66,6 +61,15 @@ const useLayerToolLogic = (
     });
   };
 
+  const {
+    fieldValidationResults,
+    fieldValidationErrors,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange,
+    setFieldValidationErrors,
+    setFieldValidationResults,
+  } = useFieldValidation(layerProperty.nodes.length);
+
   const addNode = () => {
     let initialValue: number;
     if (layerProperty.layer.operation === "multiply") {
@@ -114,75 +118,10 @@ const useLayerToolLogic = (
     ]);
   };
 
-  const [fieldValidationResults, setFieldValidationResults] = useState<
-    FieldValidationResults[]
-  >(
-    Array(layerProperty.nodes.length).fill({
-      name: true,
-      unit: true,
-      value: true,
-      valueFormat: true,
-      isValueLocked: true,
-    })
-  );
-
-  const [fieldValidationErrors, setFieldValidationErrors] = useState<
-    FieldValidationErrors[]
-  >(
-    Array(layerProperty.nodes.length).fill({
-      name: "",
-      unit: "",
-      value: "",
-      valueFormat: "",
-      isValueLocked: "",
-    })
-  );
-  const handleFieldValidationResultsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    isValid: boolean
-  ) => void = (index, fieldName, isValid) => {
-    const newResults = [...fieldValidationResults];
-    newResults[index] = { ...newResults[index], [fieldName]: isValid };
-    setFieldValidationResults(newResults);
-  };
-
-  const handleFieldValidationErrorsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    errorMessage: string
-  ) => void = (index, fieldName, errorMessage) => {
-    const newFieldValidationErrors = [...fieldValidationErrors];
-    newFieldValidationErrors[index] = {
-      ...newFieldValidationErrors[index],
-      [fieldName]: errorMessage,
-    };
-    setFieldValidationErrors(newFieldValidationErrors);
-  };
-
   const [fractionValidation, setFractionValidation] = useState(true);
   const [fractionErrorMessage, setFractionErrorMessage] = useState<
     string | null
   >(null);
-
-  const useUpdateButtonStatus = () => {
-    const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(true);
-    const areAllFieldValidationsTrue = (
-      fieldValidationResults: FieldValidationResults[]
-    ): boolean => {
-      return fieldValidationResults.every((result) => {
-        return Object.values(result).every((property) => property === true);
-      });
-    };
-
-    useEffect(() => {
-      setIsUpdateButtonDisabled(
-        !areAllFieldValidationsTrue(fieldValidationResults) ||
-          !fractionValidation
-      );
-    }, [fieldValidationResults, fractionValidation]);
-    return isUpdateButtonDisabled;
-  };
 
   const resetValidationResults = (length: number) => {
     setFieldValidationResults(
@@ -220,7 +159,6 @@ const useLayerToolLogic = (
     fieldValidationErrors,
     fractionValidation,
     fractionErrorMessage,
-    useUpdateButtonStatus,
     handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
     resetValidationResults,

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { Node, Layer, NodeFromApi } from "@/types";
+
+const useLayerToolLogic = (
+  selectedNodes: NodeFromApi[],
+  selectedLayer: Layer,
+  parentNode: NodeFromApi,
+  setFractionValidation: React.Dispatch<React.SetStateAction<boolean>>,
+  setFractionErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
+) => {
+  const [layerProperty, setlayerProperty] = useState<{
+    nodes: Node[];
+    layer: Layer;
+  }>({
+    nodes: selectedNodes,
+    layer: selectedLayer,
+  });
+
+  const [inputFraction, setInputFraction] = useState<string>(
+    selectedLayer.fraction.toString()
+  );
+
+  const handleNodeInfoChange = (index: number, newNodeInfo: Node) => {
+    const newValues = [...layerProperty.nodes];
+    newValues[index] = newNodeInfo;
+    setlayerProperty({
+      ...layerProperty,
+      nodes: newValues,
+    });
+  };
+
+  const handleOperationChange = (operation: "multiply" | "add") => {
+    const newLayerValues = { ...layerProperty.layer };
+    newLayerValues.operation = operation;
+    setlayerProperty({
+      ...layerProperty,
+      layer: newLayerValues,
+    });
+  };
+
+  const handleFractionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputFraction = e.target.value;
+    const newLayerValues = { ...layerProperty.layer };
+    setInputFraction(inputFraction);
+    const numericValue = Number(inputFraction);
+    if (isNaN(numericValue)) {
+      setFractionValidation(false);
+      setFractionErrorMessage("数値を入力してください");
+      newLayerValues.fraction = 0;
+      setlayerProperty({
+        ...layerProperty,
+        layer: newLayerValues,
+      });
+      return;
+    }
+    newLayerValues.fraction = numericValue;
+    setFractionValidation(true);
+    setFractionErrorMessage(null);
+    setlayerProperty({
+      ...layerProperty,
+      layer: newLayerValues,
+    });
+  };
+
+  const addNode = () => {
+    const newNodes = [...layerProperty.nodes];
+    let initialValue: number;
+    if (layerProperty.layer.operation === "multiply") {
+      initialValue = 1;
+    } else {
+      initialValue = 0;
+    }
+    newNodes.push({
+      name: `要素${newNodes.length + 1}`,
+      value: initialValue,
+      unit: "",
+      valueFormat: "なし",
+      isValueLocked: false,
+      parentId: parentNode.id,
+    });
+    setlayerProperty({
+      ...layerProperty,
+      nodes: newNodes,
+    });
+  };
+
+  return {
+    layerProperty,
+    setlayerProperty,
+    addNode,
+    handleNodeInfoChange,
+    handleOperationChange,
+    handleFractionChange,
+    inputFraction,
+    setInputFraction,
+  };
+};
+
+export default useLayerToolLogic;

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -62,12 +62,9 @@ const useLayerToolLogic = (
   };
 
   const {
-    fieldValidationResults,
     fieldValidationErrors,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
     setFieldValidationErrors,
-    setFieldValidationResults,
   } = useFieldValidation(layerProperty.nodes.length);
 
   const addNode = () => {
@@ -107,10 +104,10 @@ const useLayerToolLogic = (
       nodes: [...prevLayerProperty.nodes, newNode],
     }));
 
-    setFieldValidationResults((prevResults) => [
-      ...prevResults,
-      newFieldValidationResult,
-    ]);
+    // setFieldValidationResults((prevResults) => [
+    //   ...prevResults,
+    //   newFieldValidationResult,
+    // ]);
 
     setFieldValidationErrors((prevErrors) => [
       ...prevErrors,
@@ -124,15 +121,15 @@ const useLayerToolLogic = (
   >(null);
 
   const resetValidationResults = (length: number) => {
-    setFieldValidationResults(
-      Array(length).fill({
-        name: true,
-        unit: true,
-        value: true,
-        valueFormat: true,
-        isValueLocked: true,
-      })
-    );
+    // setFieldValidationResults(
+    //   Array(length).fill({
+    //     name: true,
+    //     unit: true,
+    //     value: true,
+    //     valueFormat: true,
+    //     isValueLocked: true,
+    //   })
+    // );
     setFieldValidationErrors(
       Array(length).fill({
         name: "",
@@ -155,11 +152,9 @@ const useLayerToolLogic = (
     handleFractionChange,
     inputFraction,
     setInputFraction,
-    fieldValidationResults,
     fieldValidationErrors,
     fractionValidation,
     fractionErrorMessage,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
     resetValidationResults,
   };

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -1,56 +1,35 @@
-import { useState, useEffect } from "react";
 import { Node } from "@/types";
-
-export interface FieldValidationResults {
-  name: boolean;
-  unit: boolean;
-  value: boolean;
-  valueFormat: boolean;
-  isValueLocked: boolean;
-}
-
-export interface FieldValidationErrors {
-  name: string;
-  unit: string;
-  value: string;
-  valueFormat: string;
-  isValueLocked: string;
-}
 
 const useNodeDetailLogic = (
   index: number,
   node: Node,
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void,
-  setNodeValidationResult: (index: number, isValid: boolean) => void
+  handleFieldValidationResultsChange: (
+    index: number,
+    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
+    isValid: boolean
+  ) => void,
+  handleFieldValidationErrorsChange: (
+    index: number,
+    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
+    errorMessage: string
+  ) => void
 ) => {
-  const [fieldValidationResults, setFieldValidationResults] =
-    useState<FieldValidationResults>({
-      name: true,
-      unit: true,
-      value: true,
-      valueFormat: true,
-      isValueLocked: true,
-    });
-
-  const [fieldValidationErrors, setErrors] = useState<FieldValidationErrors>({
-    name: "",
-    unit: "",
-    value: "",
-    valueFormat: "",
-    isValueLocked: "",
-  });
-
-  useEffect(() => {
-    setNodeValidationResult(
-      index,
-      Object.values(fieldValidationResults).every((result) => result)
-    );
-  }, [fieldValidationResults]);
-
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
     const name = e.target.name;
+    if (
+      !(
+        name === "name" ||
+        name === "unit" ||
+        name === "value" ||
+        name === "valueFormat" ||
+        name === "isValueLocked"
+      )
+    ) {
+      return;
+    }
     let value: string | number | boolean;
     if (e.target instanceof HTMLInputElement) {
       value =
@@ -63,98 +42,74 @@ const useNodeDetailLogic = (
     // バリデーションチェック
     if (name === "name" || name === "value") {
       if (value === null || value === "") {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          [name]: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          [name]: "必須項目です",
-        }));
+        handleFieldValidationResultsChange(index, name, false);
+        handleFieldValidationErrorsChange(index, name, "必須項目です");
         return;
       }
     }
     if (name === "value") {
       if (isNaN(Number(value))) {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          [name]: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          [name]: "数値を入力してください",
-        }));
+        handleFieldValidationResultsChange(index, name, false);
+        handleFieldValidationErrorsChange(
+          index,
+          name,
+          "数値を入力してください"
+        );
         return;
       }
     }
 
     if (name === "valueFormat") {
       if (value === "%" && updatedNodeInfo.unit !== "") {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: false,
-          valueFormat: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "％表示のときは単位を空にしてください",
-          valueFormat: "％表示のときは単位を空にしてください",
-        }));
+        handleFieldValidationResultsChange(index, "unit", false);
+        handleFieldValidationResultsChange(index, "valueFormat", false);
+        handleFieldValidationErrorsChange(
+          index,
+          "unit",
+          "％表示のときは単位を空にしてください"
+        );
+        handleFieldValidationErrorsChange(
+          index,
+          "valueFormat",
+          "％表示のときは単位を空にしてください"
+        );
         return;
       } else {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: true,
-          valueFormat: true,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "",
-          valueFormat: "",
-        }));
+        handleFieldValidationResultsChange(index, "unit", true);
+        handleFieldValidationResultsChange(index, "valueFormat", true);
+        handleFieldValidationErrorsChange(index, "unit", "");
+        handleFieldValidationErrorsChange(index, "valueFormat", "");
       }
     }
 
     if (name === "unit") {
       if (value !== "" && updatedNodeInfo.valueFormat === "%") {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: false,
-          valueFormat: false,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "％表示のときは単位を空にしてください",
-          valueFormat: "％表示のときは単位を空にしてください",
-        }));
+        handleFieldValidationResultsChange(index, "unit", false);
+        handleFieldValidationResultsChange(index, "valueFormat", false);
+        handleFieldValidationErrorsChange(
+          index,
+          "unit",
+          "％表示のときは単位を空にしてください"
+        );
+        handleFieldValidationErrorsChange(
+          index,
+          "valueFormat",
+          "％表示のときは単位を空にしてください"
+        );
         return;
       } else {
-        setFieldValidationResults((prev) => ({
-          ...prev,
-          unit: true,
-          valueFormat: true,
-        }));
-        setErrors((prev) => ({
-          ...prev,
-          unit: "",
-          valueFormat: "",
-        }));
+        handleFieldValidationResultsChange(index, "unit", true);
+        handleFieldValidationResultsChange(index, "valueFormat", true);
+        handleFieldValidationErrorsChange(index, "unit", "");
+        handleFieldValidationErrorsChange(index, "valueFormat", "");
       }
     }
 
-    setFieldValidationResults((prev) => ({
-      ...prev,
-      [name]: true,
-    }));
-    setErrors((prev) => ({
-      ...prev,
-      [name]: "",
-    }));
+    handleFieldValidationResultsChange(index, name, true);
+    handleFieldValidationErrorsChange(index, name, "");
   };
 
   return {
-    fieldValidationResults,
-    fieldValidationErrors,
     handleInputChange,
   };
 };

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -1,0 +1,162 @@
+import { useState, useEffect } from "react";
+import { Node } from "@/types";
+
+export interface FieldValidationResults {
+  name: boolean;
+  unit: boolean;
+  value: boolean;
+  valueFormat: boolean;
+  isValueLocked: boolean;
+}
+
+export interface FieldValidationErrors {
+  name: string;
+  unit: string;
+  value: string;
+  valueFormat: string;
+  isValueLocked: string;
+}
+
+const useNodeDetailLogic = (
+  index: number,
+  node: Node,
+  handleNodeInfoChange: (index: number, newNodeInfo: Node) => void,
+  setNodeValidationResult: (index: number, isValid: boolean) => void
+) => {
+  const [fieldValidationResults, setFieldValidationResults] =
+    useState<FieldValidationResults>({
+      name: true,
+      unit: true,
+      value: true,
+      valueFormat: true,
+      isValueLocked: true,
+    });
+
+  const [fieldValidationErrors, setErrors] = useState<FieldValidationErrors>({
+    name: "",
+    unit: "",
+    value: "",
+    valueFormat: "",
+    isValueLocked: "",
+  });
+
+  useEffect(() => {
+    setNodeValidationResult(
+      index,
+      Object.values(fieldValidationResults).every((result) => result)
+    );
+  }, [fieldValidationResults]);
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const name = e.target.name;
+    let value: string | number | boolean;
+    if (e.target instanceof HTMLInputElement) {
+      value =
+        e.target.type === "checkbox" ? e.target.checked : e.target.value.trim();
+    } else {
+      value = e.target.value.trim();
+    }
+    const updatedNodeInfo = { ...node, [name]: value };
+    handleNodeInfoChange(index, updatedNodeInfo);
+    // バリデーションチェック
+    if (name === "name" || name === "value") {
+      if (value === null || value === "") {
+        setFieldValidationResults((prev) => ({
+          ...prev,
+          [name]: false,
+        }));
+        setErrors((prev) => ({
+          ...prev,
+          [name]: "必須項目です",
+        }));
+        return;
+      }
+    }
+    if (name === "value") {
+      if (isNaN(Number(value))) {
+        setFieldValidationResults((prev) => ({
+          ...prev,
+          [name]: false,
+        }));
+        setErrors((prev) => ({
+          ...prev,
+          [name]: "数値を入力してください",
+        }));
+        return;
+      }
+    }
+
+    if (name === "valueFormat") {
+      if (value === "%" && updatedNodeInfo.unit !== "") {
+        setFieldValidationResults((prev) => ({
+          ...prev,
+          unit: false,
+          valueFormat: false,
+        }));
+        setErrors((prev) => ({
+          ...prev,
+          unit: "％表示のときは単位を空にしてください",
+          valueFormat: "％表示のときは単位を空にしてください",
+        }));
+        return;
+      } else {
+        setFieldValidationResults((prev) => ({
+          ...prev,
+          unit: true,
+          valueFormat: true,
+        }));
+        setErrors((prev) => ({
+          ...prev,
+          unit: "",
+          valueFormat: "",
+        }));
+      }
+    }
+
+    if (name === "unit") {
+      if (value !== "" && updatedNodeInfo.valueFormat === "%") {
+        setFieldValidationResults((prev) => ({
+          ...prev,
+          unit: false,
+          valueFormat: false,
+        }));
+        setErrors((prev) => ({
+          ...prev,
+          unit: "％表示のときは単位を空にしてください",
+          valueFormat: "％表示のときは単位を空にしてください",
+        }));
+        return;
+      } else {
+        setFieldValidationResults((prev) => ({
+          ...prev,
+          unit: true,
+          valueFormat: true,
+        }));
+        setErrors((prev) => ({
+          ...prev,
+          unit: "",
+          valueFormat: "",
+        }));
+      }
+    }
+
+    setFieldValidationResults((prev) => ({
+      ...prev,
+      [name]: true,
+    }));
+    setErrors((prev) => ({
+      ...prev,
+      [name]: "",
+    }));
+  };
+
+  return {
+    fieldValidationResults,
+    fieldValidationErrors,
+    handleInputChange,
+  };
+};
+
+export default useNodeDetailLogic;

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -4,11 +4,6 @@ const useNodeDetailLogic = (
   index: number,
   node: Node,
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void,
-  handleFieldValidationResultsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    isValid: boolean
-  ) => void,
   handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void
 ) => {
   const handleInputChange = (
@@ -38,7 +33,6 @@ const useNodeDetailLogic = (
     // バリデーションチェック
     if (name === "name" || name === "value") {
       if (value === null || value === "") {
-        handleFieldValidationResultsChange(index, name, false);
         handleFieldValidationErrorsChange([
           { index: index, fieldName: name, errorMessage: "必須項目です" },
         ]);
@@ -47,7 +41,6 @@ const useNodeDetailLogic = (
     }
     if (name === "value") {
       if (isNaN(Number(value))) {
-        handleFieldValidationResultsChange(index, name, false);
         handleFieldValidationErrorsChange([
           {
             index: index,
@@ -61,8 +54,6 @@ const useNodeDetailLogic = (
 
     if (name === "valueFormat") {
       if (value === "%" && updatedNodeInfo.unit !== "") {
-        handleFieldValidationResultsChange(index, "unit", false);
-        handleFieldValidationResultsChange(index, "valueFormat", false);
         handleFieldValidationErrorsChange([
           {
             index: index,
@@ -77,8 +68,6 @@ const useNodeDetailLogic = (
         ]);
         return;
       } else {
-        handleFieldValidationResultsChange(index, "unit", true);
-        handleFieldValidationResultsChange(index, "valueFormat", true);
         handleFieldValidationErrorsChange([
           {
             index: index,
@@ -96,8 +85,6 @@ const useNodeDetailLogic = (
 
     if (name === "unit") {
       if (value !== "" && updatedNodeInfo.valueFormat === "%") {
-        handleFieldValidationResultsChange(index, "unit", false);
-        handleFieldValidationResultsChange(index, "valueFormat", false);
         handleFieldValidationErrorsChange([
           {
             index: index,
@@ -112,8 +99,6 @@ const useNodeDetailLogic = (
         ]);
         return;
       } else {
-        handleFieldValidationResultsChange(index, "unit", true);
-        handleFieldValidationResultsChange(index, "valueFormat", true);
         handleFieldValidationErrorsChange([
           {
             index: index,
@@ -128,15 +113,8 @@ const useNodeDetailLogic = (
         ]);
       }
     }
-
-    handleFieldValidationResultsChange(index, name, true);
-
     handleFieldValidationErrorsChange([
-      { index: index, fieldName: "name", errorMessage: "" },
-      { index: index, fieldName: "unit", errorMessage: "" },
-      { index: index, fieldName: "value", errorMessage: "" },
-      { index: index, fieldName: "valueFormat", errorMessage: "" },
-      { index: index, fieldName: "isValueLocked", errorMessage: "" },
+      { index: index, fieldName: name, errorMessage: "" },
     ]);
   };
 

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -31,16 +31,24 @@ const useNodeDetailLogic = (
     const updatedNodeInfo = { ...node, [name]: value };
     handleNodeInfoChange(index, updatedNodeInfo);
     // バリデーションチェック
-    if (name === "name" || name === "value") {
+    if (name === "name") {
+      if (value === null || value === "") {
+        handleFieldValidationErrorsChange([
+          { index: index, fieldName: "name", errorMessage: "必須項目です" },
+        ]);
+      } else {
+        handleFieldValidationErrorsChange([
+          { index: index, fieldName: "name", errorMessage: "" },
+        ]);
+      }
+      return;
+    }
+    if (name === "value") {
       if (value === null || value === "") {
         handleFieldValidationErrorsChange([
           { index: index, fieldName: name, errorMessage: "必須項目です" },
         ]);
-        return;
-      }
-    }
-    if (name === "value") {
-      if (isNaN(Number(value))) {
+      } else if (isNaN(Number(value))) {
         handleFieldValidationErrorsChange([
           {
             index: index,
@@ -48,8 +56,12 @@ const useNodeDetailLogic = (
             errorMessage: "数値を入力してください",
           },
         ]);
-        return;
+      } else {
+        handleFieldValidationErrorsChange([
+          { index: index, fieldName: name, errorMessage: "" },
+        ]);
       }
+      return;
     }
 
     if (name === "valueFormat") {
@@ -66,7 +78,6 @@ const useNodeDetailLogic = (
             errorMessage: "％表示のときは単位を空にしてください",
           },
         ]);
-        return;
       } else {
         handleFieldValidationErrorsChange([
           {
@@ -81,6 +92,7 @@ const useNodeDetailLogic = (
           },
         ]);
       }
+      return;
     }
 
     if (name === "unit") {
@@ -97,7 +109,6 @@ const useNodeDetailLogic = (
             errorMessage: "％表示のときは単位を空にしてください",
           },
         ]);
-        return;
       } else {
         handleFieldValidationErrorsChange([
           {
@@ -112,6 +123,7 @@ const useNodeDetailLogic = (
           },
         ]);
       }
+      return;
     }
     handleFieldValidationErrorsChange([
       { index: index, fieldName: name, errorMessage: "" },

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -1,4 +1,4 @@
-import { Node } from "@/types";
+import { Node, FieldValidationError } from "@/types";
 
 const useNodeDetailLogic = (
   index: number,
@@ -9,11 +9,7 @@ const useNodeDetailLogic = (
     fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
     isValid: boolean
   ) => void,
-  handleFieldValidationErrorsChange: (
-    index: number,
-    fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked",
-    errorMessage: string
-  ) => void
+  handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void
 ) => {
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
@@ -43,18 +39,22 @@ const useNodeDetailLogic = (
     if (name === "name" || name === "value") {
       if (value === null || value === "") {
         handleFieldValidationResultsChange(index, name, false);
-        handleFieldValidationErrorsChange(index, name, "必須項目です");
+        handleFieldValidationErrorsChange([
+          { index: index, fieldName: name, errorMessage: "必須項目です" },
+        ]);
         return;
       }
     }
     if (name === "value") {
       if (isNaN(Number(value))) {
         handleFieldValidationResultsChange(index, name, false);
-        handleFieldValidationErrorsChange(
-          index,
-          name,
-          "数値を入力してください"
-        );
+        handleFieldValidationErrorsChange([
+          {
+            index: index,
+            fieldName: name,
+            errorMessage: "数値を入力してください",
+          },
+        ]);
         return;
       }
     }
@@ -63,22 +63,34 @@ const useNodeDetailLogic = (
       if (value === "%" && updatedNodeInfo.unit !== "") {
         handleFieldValidationResultsChange(index, "unit", false);
         handleFieldValidationResultsChange(index, "valueFormat", false);
-        handleFieldValidationErrorsChange(
-          index,
-          "unit",
-          "％表示のときは単位を空にしてください"
-        );
-        handleFieldValidationErrorsChange(
-          index,
-          "valueFormat",
-          "％表示のときは単位を空にしてください"
-        );
+        handleFieldValidationErrorsChange([
+          {
+            index: index,
+            fieldName: "unit",
+            errorMessage: "％表示のときは単位を空にしてください",
+          },
+          {
+            index: index,
+            fieldName: "valueFormat",
+            errorMessage: "％表示のときは単位を空にしてください",
+          },
+        ]);
         return;
       } else {
         handleFieldValidationResultsChange(index, "unit", true);
         handleFieldValidationResultsChange(index, "valueFormat", true);
-        handleFieldValidationErrorsChange(index, "unit", "");
-        handleFieldValidationErrorsChange(index, "valueFormat", "");
+        handleFieldValidationErrorsChange([
+          {
+            index: index,
+            fieldName: "unit",
+            errorMessage: "",
+          },
+          {
+            index: index,
+            fieldName: "valueFormat",
+            errorMessage: "",
+          },
+        ]);
       }
     }
 
@@ -86,27 +98,46 @@ const useNodeDetailLogic = (
       if (value !== "" && updatedNodeInfo.valueFormat === "%") {
         handleFieldValidationResultsChange(index, "unit", false);
         handleFieldValidationResultsChange(index, "valueFormat", false);
-        handleFieldValidationErrorsChange(
-          index,
-          "unit",
-          "％表示のときは単位を空にしてください"
-        );
-        handleFieldValidationErrorsChange(
-          index,
-          "valueFormat",
-          "％表示のときは単位を空にしてください"
-        );
+        handleFieldValidationErrorsChange([
+          {
+            index: index,
+            fieldName: "unit",
+            errorMessage: "％表示のときは単位を空にしてください",
+          },
+          {
+            index: index,
+            fieldName: "valueFormat",
+            errorMessage: "％表示のときは単位を空にしてください",
+          },
+        ]);
         return;
       } else {
         handleFieldValidationResultsChange(index, "unit", true);
         handleFieldValidationResultsChange(index, "valueFormat", true);
-        handleFieldValidationErrorsChange(index, "unit", "");
-        handleFieldValidationErrorsChange(index, "valueFormat", "");
+        handleFieldValidationErrorsChange([
+          {
+            index: index,
+            fieldName: "unit",
+            errorMessage: "",
+          },
+          {
+            index: index,
+            fieldName: "valueFormat",
+            errorMessage: "",
+          },
+        ]);
       }
     }
 
     handleFieldValidationResultsChange(index, name, true);
-    handleFieldValidationErrorsChange(index, name, "");
+
+    handleFieldValidationErrorsChange([
+      { index: index, fieldName: "name", errorMessage: "" },
+      { index: index, fieldName: "unit", errorMessage: "" },
+      { index: index, fieldName: "value", errorMessage: "" },
+      { index: index, fieldName: "valueFormat", errorMessage: "" },
+      { index: index, fieldName: "isValueLocked", errorMessage: "" },
+    ]);
   };
 
   return {

--- a/app/javascript/hooks/useRootNodeToolLogic.ts
+++ b/app/javascript/hooks/useRootNodeToolLogic.ts
@@ -5,12 +5,8 @@ import useFieldValidation from "@/hooks/useFieldValidation";
 const useRootNodeToolLogic = (selectedRootNode: NodeFromApi) => {
   const [nodeInfo, setNodeInfo] = useState<Node>(selectedRootNode);
 
-  const {
-    fieldValidationResults,
-    fieldValidationErrors,
-    handleFieldValidationResultsChange,
-    handleFieldValidationErrorsChange,
-  } = useFieldValidation(1);
+  const { fieldValidationErrors, handleFieldValidationErrorsChange } =
+    useFieldValidation(1);
 
   const handleNodeInfoChange = (_index = 0, newNodeInfo: Node) => {
     setNodeInfo(newNodeInfo);
@@ -19,9 +15,7 @@ const useRootNodeToolLogic = (selectedRootNode: NodeFromApi) => {
   return {
     nodeInfo,
     handleNodeInfoChange,
-    fieldValidationResults,
     fieldValidationErrors,
-    handleFieldValidationResultsChange,
     handleFieldValidationErrorsChange,
   };
 };

--- a/app/javascript/hooks/useRootNodeToolLogic.ts
+++ b/app/javascript/hooks/useRootNodeToolLogic.ts
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { Node, NodeFromApi } from "@/types";
+import useFieldValidation from "@/hooks/useFieldValidation";
+
+const useRootNodeToolLogic = (selectedRootNode: NodeFromApi) => {
+  const [nodeInfo, setNodeInfo] = useState<Node>(selectedRootNode);
+
+  const {
+    fieldValidationResults,
+    fieldValidationErrors,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange,
+  } = useFieldValidation(1);
+
+  const handleNodeInfoChange = (_index = 0, newNodeInfo: Node) => {
+    setNodeInfo(newNodeInfo);
+  };
+
+  return {
+    nodeInfo,
+    handleNodeInfoChange,
+    fieldValidationResults,
+    fieldValidationErrors,
+    handleFieldValidationResultsChange,
+    handleFieldValidationErrorsChange,
+  };
+};
+
+export default useRootNodeToolLogic;

--- a/app/javascript/hooks/useUpdateButtonStatus.ts
+++ b/app/javascript/hooks/useUpdateButtonStatus.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+import { FieldValidationResults, FieldValidationErrors } from "@/types";
+
+const useUpdateButtonStatus = (
+  fieldValidationResults: FieldValidationResults[],
+  isRoot: boolean,
+  fractionValidation?: boolean
+) => {
+  const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(true);
+
+  useEffect(() => {
+    const areAllFieldValidationsTrue = fieldValidationResults.every(
+      (result) => {
+        return Object.values(result).every((property) => property === true);
+      }
+    );
+    if (isRoot) {
+      setIsUpdateButtonDisabled(!areAllFieldValidationsTrue);
+      return;
+    }
+    setIsUpdateButtonDisabled(
+      !areAllFieldValidationsTrue || !fractionValidation
+    );
+  }, [fieldValidationResults, fractionValidation]);
+
+  return isUpdateButtonDisabled;
+};
+
+export default useUpdateButtonStatus;

--- a/app/javascript/hooks/useUpdateButtonStatus.ts
+++ b/app/javascript/hooks/useUpdateButtonStatus.ts
@@ -1,19 +1,17 @@
 import { useState, useEffect } from "react";
-import { FieldValidationResults, FieldValidationErrors } from "@/types";
+import { FieldValidationErrors } from "@/types";
 
 const useUpdateButtonStatus = (
-  fieldValidationResults: FieldValidationResults[],
+  fieldValidationErrors: FieldValidationErrors[],
   isRoot: boolean,
   fractionValidation?: boolean
 ) => {
   const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(true);
 
   useEffect(() => {
-    const areAllFieldValidationsTrue = fieldValidationResults.every(
-      (result) => {
-        return Object.values(result).every((property) => property === true);
-      }
-    );
+    const areAllFieldValidationsTrue = fieldValidationErrors.every((result) => {
+      return Object.values(result).every((property) => property === "");
+    });
     if (isRoot) {
       setIsUpdateButtonDisabled(!areAllFieldValidationsTrue);
       return;
@@ -21,7 +19,7 @@ const useUpdateButtonStatus = (
     setIsUpdateButtonDisabled(
       !areAllFieldValidationsTrue || !fractionValidation
     );
-  }, [fieldValidationResults, fractionValidation]);
+  }, [fieldValidationErrors, fractionValidation]);
 
   return isUpdateButtonDisabled;
 };

--- a/app/javascript/hooks/useValidationLogic.ts
+++ b/app/javascript/hooks/useValidationLogic.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+
+const useValidationLogic = (initialLength: number) => {
+  const [nodeValidationResults, setNodeValidationResults] = useState<boolean[]>(
+    Array(initialLength).fill(true)
+  );
+  const [fractionValidation, setFractionValidation] = useState(true);
+  const [fractionErrorMessage, setFractionErrorMessage] = useState<
+    string | null
+  >(null);
+
+  const isAllValid = (results: boolean[]): boolean => {
+    return results.every((result) => result);
+  };
+
+  const handleNodeValidationResultsChange = (
+    index: number,
+    isValid: boolean
+  ) => {
+    const newValues = [...nodeValidationResults];
+    newValues[index] = isValid;
+    setNodeValidationResults(newValues);
+  };
+
+  const useUpdateButtonStatus = () => {
+    const [isUpdateButtonDisabled, setIsUpdateButtonDisabled] = useState(true);
+    useEffect(() => {
+      setIsUpdateButtonDisabled(
+        !isAllValid(nodeValidationResults) || !fractionValidation
+      );
+    }, [nodeValidationResults, fractionValidation]);
+    return isUpdateButtonDisabled;
+  };
+
+  return {
+    setNodeValidationResults,
+    handleNodeValidationResultsChange,
+    fractionValidation,
+    setFractionValidation,
+    fractionErrorMessage,
+    setFractionErrorMessage,
+    useUpdateButtonStatus,
+  };
+};
+
+export default useValidationLogic;

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -76,3 +76,19 @@ export type TreeData = {
   nodes: Node[];
   layers: Layer[];
 };
+
+export interface FieldValidationResults {
+  name: boolean;
+  unit: boolean;
+  value: boolean;
+  valueFormat: boolean;
+  isValueLocked: boolean;
+}
+
+export interface FieldValidationErrors {
+  name: string;
+  unit: string;
+  value: string;
+  valueFormat: string;
+  isValueLocked: string;
+}

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -92,3 +92,9 @@ export interface FieldValidationErrors {
   valueFormat: string;
   isValueLocked: string;
 }
+
+export interface FieldValidationError {
+  index: number;
+  fieldName: "name" | "unit" | "value" | "valueFormat" | "isValueLocked";
+  errorMessage: string;
+}

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -77,14 +77,6 @@ export type TreeData = {
   layers: Layer[];
 };
 
-export interface FieldValidationResults {
-  name: boolean;
-  unit: boolean;
-  value: boolean;
-  valueFormat: boolean;
-  isValueLocked: boolean;
-}
-
 export interface FieldValidationErrors {
   name: string;
   unit: string;

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include ExpectHelper
 end

--- a/spec/support/expect_helper.rb
+++ b/spec/support/expect_helper.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module ExpectHelper
+  def expect_node_detail(index:, name:, value:, unit:, value_format:, is_value_locked:)
+    expect_selector(index, 'name', name)
+    expect_selector(index, 'value', value)
+    expect_selector(index, 'unit', unit)
+    expect(page).to have_select("node-#{index}-valueFormat", selected: value_format.to_s)
+    expect_value_locked(index, is_value_locked)
+  end
+
+  def expect_tree_node(name:, display_value:, is_value_locked:, is_leaf:, operation: nil)
+    node_svg = if is_leaf
+                 find('g > text', text: name).ancestor('g.rd3t-leaf-node')
+               else
+                 find('g > text', text: name).ancestor('g.rd3t-node')
+               end
+    expect(node_svg).to have_text(display_value)
+    if is_value_locked
+      expect(node_svg).to have_css('svg.fa-lock')
+    else
+      expect(node_svg).not_to have_css('svg.fa-lock')
+    end
+    expect_operation_display(node_svg:, operation:) if operation.present?
+  end
+
+  private
+
+  def expect_selector(index, attribute, value)
+    expect(page).to have_selector("#node-detail-#{index} input[name='#{attribute}'][value='#{value}']")
+  end
+
+  def expect_value_locked(index, is_value_locked)
+    if is_value_locked
+      expect(page).to have_selector("#node-detail-#{index} input[name='isValueLocked'][type='checkbox'](:checked)")
+    else
+      expect(page).to have_selector("#node-detail-#{index} input[name='isValueLocked'][type='checkbox']:not(:checked)")
+    end
+  end
+
+  def expect_operation_display(node_svg:, operation:)
+    case operation
+    when 'multiply'
+      expect(node_svg).to have_text('×').and have_no_text('＋')
+    when 'add'
+      expect(node_svg).to have_text('＋').and have_no_text('×')
+    else
+      expect(node_svg).to have_no_text('×').and have_no_text('＋')
+    end
+  end
+end

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
@@ -39,7 +39,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: false
       )
 
-      expect_node_display(
+      expect_tree_node(
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
@@ -47,7 +47,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: true
       )
 
-      expect_node_display(
+      expect_tree_node(
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
@@ -81,14 +81,14 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
         operation: '',
         is_leaf: false
       )
-      expect_node_display(
+      expect_tree_node(
         name: '変更後のノード名1',
         display_value: '2千人（変更後）',
         is_value_locked: true,
@@ -96,7 +96,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: true
       )
 
-      expect_node_display(
+      expect_tree_node(
         name: '変更後のノード名2',
         display_value: '4000円（変更後）',
         is_value_locked: true,
@@ -114,7 +114,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
@@ -122,7 +122,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: false
       )
 
-      expect_node_display(
+      expect_tree_node(
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
@@ -130,7 +130,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: true
       )
 
-      expect_node_display(
+      expect_tree_node(
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
@@ -176,14 +176,14 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート',
         display_value: '1000万円',
         is_value_locked: true,
         operation: '',
         is_leaf: false
       )
-      expect_node_display(
+      expect_tree_node(
         name: '子1\'',
         display_value: '2千人（変更後）',
         is_value_locked: true,
@@ -191,7 +191,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: true
       )
 
-      expect_node_display(
+      expect_tree_node(
         name: '子2\'',
         display_value: '4000円（変更後）',
         is_value_locked: true,
@@ -219,21 +219,21 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート\'',
         display_value: '500千円\'',
         is_value_locked: false,
         operation: '',
         is_leaf: false
       )
-      expect_node_display(
+      expect_tree_node(
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
         operation: 'multiply',
         is_leaf: true
       )
-      expect_node_display(
+      expect_tree_node(
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
@@ -250,7 +250,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      expect_node_display(
+      expect_tree_node(
         name: '子1\'',
         display_value: '4千人',
         is_value_locked: false,
@@ -266,7 +266,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      expect_node_display(
+      expect_tree_node(
         name: '子1\'\'',
         display_value: '1.5万人',
         is_value_locked: false,
@@ -282,7 +282,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      expect_node_display(
+      expect_tree_node(
         name: '子1\'\'\'',
         display_value: '2500.1人',
         is_value_locked: false,
@@ -332,14 +332,14 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 選択したノードの更新に基づいて親ノードの値も更新されていること、さらにその親ノードはisValueLocked: true なので、値は変わらないことを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート',
         display_value: '1000万円', # isValueLocked: true なので、値は変わらない
         is_value_locked: true,
         operation: '',
         is_leaf: false
       )
-      expect_node_display(
+      expect_tree_node(
         name: '子1',
         display_value: '14500人', # 1万 + 2500 + 2000 に更新される
         is_value_locked: false,
@@ -372,7 +372,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('.modal-action label', text: '更新する').click
 
       # 更新後のツリー表示が想定どおりであることを確認
-      expect_node_display(
+      expect_tree_node(
         name: 'ルート\'',
         display_value: '500千円\'',
         is_value_locked: false,
@@ -436,21 +436,21 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       click_button '要素を追加'
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
-      expect_node_display(
+      expect_tree_node(
         name: '子1',
         display_value: '5000人',
         is_value_locked: false,
         operation: 'multiply',
         is_leaf: true
       )
-      expect_node_display(
+      expect_tree_node(
         name: '子2',
         display_value: '2000円',
         is_value_locked: false,
         operation: 'multiply',
         is_leaf: true
       )
-      expect_node_display(
+      expect_tree_node(
         name: '要素3',
         display_value: '1',
         is_value_locked: false,
@@ -485,21 +485,21 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('#updateButton label', text: '更新').click
       find('.modal-action label', text: '更新する').click
 
-      expect_node_display(
+      expect_tree_node(
         name: '変更後のノード名1',
         display_value: '2千人（変更後）',
         is_value_locked: true,
         operation: 'multiply',
         is_leaf: true
       )
-      expect_node_display(
+      expect_tree_node(
         name: '変更後のノード名2',
         display_value: '4000円（変更後）',
         is_value_locked: true,
         operation: 'multiply',
         is_leaf: true
       )
-      expect_node_display(
+      expect_tree_node(
         name: '変更後のノード名3',
         display_value: '0.1千円',
         is_value_locked: true,
@@ -507,31 +507,5 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         is_leaf: true
       )
     end
-  end
-end
-
-def expect_node_display(name:, display_value:, is_value_locked:, is_leaf:, operation: nil)
-  node_svg = if is_leaf
-               find('g > text', text: name).ancestor('g.rd3t-leaf-node')
-             else
-               find('g > text', text: name).ancestor('g.rd3t-node')
-             end
-  expect(node_svg).to have_text(display_value)
-  if is_value_locked
-    expect(node_svg).to have_css('svg.fa-lock')
-  else
-    expect(node_svg).not_to have_css('svg.fa-lock')
-  end
-  expect_operation_display(node_svg:, operation:) if operation.present?
-end
-
-def expect_operation_display(node_svg:, operation:)
-  case operation
-  when 'multiply'
-    expect(node_svg).to have_text('×').and have_no_text('＋')
-  when 'add'
-    expect(node_svg).to have_text('＋').and have_no_text('×')
-  else
-    expect(node_svg).to have_no_text('×').and have_no_text('＋')
   end
 end


### PR DESCRIPTION
close #191 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/191

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 別な階層を選択してもノード詳細が更新されない問題に対応
  - input要素に対して、valueでなくdefaultValueでノード詳細を渡していたため、値が更新されていなかったことが原因
  - 該当ケースを確認できるテストを追加
- 上記修正に伴いバリデーションエラーが正しく出ていないことも検知できたため、修正
  - バリデーションエラーの管理をNodeDetailからLayerTool / RootNodeToolにリフトアップし、selectedNodesの変更をトリガーにしてリセットできるようにした
  - これを機にコンポーネントのロジックをカスタムフックに切り出した

## 動作確認方法
1. VSCode Remote Containerで開発環境を起動
1. bin/devを実行してから、http://localhost:3001/ にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する
1. Googleアカウントでログインしたユーザーでツリーを作成 or 既存のツリーのユーザーをログインしたユーザーに変更する
1. ツリー編集画面にアクセスし、任意の要素をクリックしてツールエリアを開く
1. 別な要素をクリックすると、ツールエリアの表示が選択した階層の内容に変わることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛
