### PR TITLE
ノード削除機能

### DIFF
--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -21,6 +21,7 @@ module Api
       begin
         ActiveRecord::Base.transaction do
           (@nodes + @layers).each(&:save!)
+          delete_nodes_not_in_params
         end
       rescue ActiveRecord::RecordInvalid => e
         render json: { errors: e.record.errors.full_messages, record: e.record }, status: :unprocessable_entity
@@ -64,6 +65,12 @@ module Api
         layer.parent_node_id = layer_param[:parent_node_id]
         layer
       end
+    end
+
+    def delete_nodes_not_in_params
+      node_ids_in_params = tree_params[:nodes].pluck(:id).compact
+      nodes_to_delete = @tree.nodes.where.not(id: node_ids_in_params)
+      nodes_to_delete.destroy_all
     end
   end
 end

--- a/app/javascript/components/shared/ToolMenu.tsx
+++ b/app/javascript/components/shared/ToolMenu.tsx
@@ -13,7 +13,7 @@ type Props = {
 const ToolMenu: React.FC<Props> = ({ menuItems }) => {
   return (
     <>
-      <div className="dropdown dropdown-bottom dropdown-end">
+      <div className="dropdown dropdown-bottom dropdown-end tool-menu">
         <label tabIndex={0} className="btn btn-ghost btn-sm">
           <FontAwesomeIcon icon={faEllipsis} />
         </label>

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -122,6 +122,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
               handleFieldValidationErrorsChange={
                 handleFieldValidationErrorsChange
               }
+              showToolMenu={layerProperty.nodes.length > 2}
             />
           ))}
           <div className="flex justify-center">

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -34,6 +34,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
     layerProperty,
     setlayerProperty,
     addNode,
+    deleteNode,
     handleNodeInfoChange,
     handleOperationChange,
     handleFractionChange,
@@ -123,6 +124,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
                 handleFieldValidationErrorsChange
               }
               showToolMenu={layerProperty.nodes.length > 2}
+              deleteNode={deleteNode}
             />
           ))}
           <div className="flex justify-center">

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -58,6 +58,10 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
     }
   };
 
+  const mockDeleteNode = (index = 0) => {
+    console.log(`delete node ${index}`);
+  };
+
   return (
     <>
       <div className="relative flex flex-col h-full">
@@ -72,7 +76,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
               handleFieldValidationErrorsChange
             }
             showToolMenu={false}
-            deleteNode={() => {}}
+            deleteNode={mockDeleteNode}
           />
         </div>
         <div

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -71,6 +71,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
             handleFieldValidationErrorsChange={
               handleFieldValidationErrorsChange
             }
+            showToolMenu={false}
           />
         </div>
         <div

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -72,6 +72,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
               handleFieldValidationErrorsChange
             }
             showToolMenu={false}
+            deleteNode={() => {}}
           />
         </div>
         <div

--- a/app/javascript/components/trees/tool/calculationArea/Calculation.tsx
+++ b/app/javascript/components/trees/tool/calculationArea/Calculation.tsx
@@ -54,7 +54,7 @@ const Calculation: React.FC<CalculationProps> = ({
                 name={node.name}
                 value={node.value}
                 displayUnit={getDisplayUnit(node)}
-                elementId={index}
+                elementId={index + 1}
               />
               {!(index === maxIndex) && (
                 <OperationSymbol operation={selectedLayer.operation} />

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -10,6 +10,7 @@ export type NodeDetailProps = {
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
   fieldValidationErrors: FieldValidationErrors;
   handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void;
+  showToolMenu: boolean;
 };
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,
@@ -17,6 +18,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
   handleNodeInfoChange,
   fieldValidationErrors,
   handleFieldValidationErrorsChange,
+  showToolMenu,
 }) => {
   const { handleInputChange } = useNodeDetailLogic(
     index,
@@ -33,16 +35,18 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
       >
         <legend>{`要素${index + 1}`}</legend>
         <div className="absolute right-0 top-2 mt-1.5">
-          <ToolMenu
-            menuItems={[
-              {
-                label: "要素を削除",
-                onClick: () => {
-                  console.log("要素を削除");
+          {showToolMenu && (
+            <ToolMenu
+              menuItems={[
+                {
+                  label: "要素を削除",
+                  onClick: () => {
+                    console.log("要素を削除");
+                  },
                 },
-              },
-            ]}
-          />
+              ]}
+            />
+          )}
         </div>
         <div className="flex flex-row space-x-4 mb-1.5">
           <NodeField

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -11,6 +11,7 @@ export type NodeDetailProps = {
   fieldValidationErrors: FieldValidationErrors;
   handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void;
   showToolMenu: boolean;
+  deleteNode: (index: number) => void;
 };
 const NodeDetail: React.FC<NodeDetailProps> = ({
   index,
@@ -19,6 +20,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
   fieldValidationErrors,
   handleFieldValidationErrorsChange,
   showToolMenu,
+  deleteNode,
 }) => {
   const { handleInputChange } = useNodeDetailLogic(
     index,
@@ -40,9 +42,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
               menuItems={[
                 {
                   label: "要素を削除",
-                  onClick: () => {
-                    console.log("要素を削除");
-                  },
+                  onClick: () => deleteNode(index),
                 },
               ]}
             />

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -83,14 +83,6 @@ const useLayerToolLogic = (
       parentId: parentNode.id,
     };
 
-    const newFieldValidationResult = {
-      name: true,
-      unit: true,
-      value: true,
-      valueFormat: true,
-      isValueLocked: true,
-    };
-
     const newFieldValidationError = {
       name: "",
       unit: "",
@@ -104,11 +96,6 @@ const useLayerToolLogic = (
       nodes: [...prevLayerProperty.nodes, newNode],
     }));
 
-    // setFieldValidationResults((prevResults) => [
-    //   ...prevResults,
-    //   newFieldValidationResult,
-    // ]);
-
     setFieldValidationErrors((prevErrors) => [
       ...prevErrors,
       newFieldValidationError,
@@ -121,15 +108,6 @@ const useLayerToolLogic = (
   >(null);
 
   const resetValidationResults = (length: number) => {
-    // setFieldValidationResults(
-    //   Array(length).fill({
-    //     name: true,
-    //     unit: true,
-    //     value: true,
-    //     valueFormat: true,
-    //     isValueLocked: true,
-    //   })
-    // );
     setFieldValidationErrors(
       Array(length).fill({
         name: "",

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -102,6 +102,25 @@ const useLayerToolLogic = (
     ]);
   };
 
+  const deleteNode = (index: number) => {
+    const newNodes = [...layerProperty.nodes];
+    newNodes.splice(index, 1);
+    console.log("deleteNode");
+    console.log({
+      ...layerProperty,
+      nodes: newNodes,
+    });
+    setLayerProperty({
+      ...layerProperty,
+      nodes: newNodes,
+    });
+    setFieldValidationErrors((prevErrors) => {
+      const newErrors = [...prevErrors];
+      newErrors.splice(index, 1);
+      return newErrors;
+    });
+  };
+
   const [fractionValidation, setFractionValidation] = useState(true);
   const [fractionErrorMessage, setFractionErrorMessage] = useState<
     string | null
@@ -125,6 +144,7 @@ const useLayerToolLogic = (
     layerProperty,
     setlayerProperty: setLayerProperty,
     addNode,
+    deleteNode,
     handleNodeInfoChange,
     handleOperationChange,
     handleFractionChange,

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -105,11 +105,6 @@ const useLayerToolLogic = (
   const deleteNode = (index: number) => {
     const newNodes = [...layerProperty.nodes];
     newNodes.splice(index, 1);
-    console.log("deleteNode");
-    console.log({
-      ...layerProperty,
-      nodes: newNodes,
-    });
     setLayerProperty({
       ...layerProperty,
       nodes: newNodes,

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -34,11 +34,11 @@ const useNodeDetailLogic = (
     if (name === "name") {
       if (value === null || value === "") {
         handleFieldValidationErrorsChange([
-          { index: index, fieldName: "name", errorMessage: "必須項目です" },
+          { index, fieldName: "name", errorMessage: "必須項目です" },
         ]);
       } else {
         handleFieldValidationErrorsChange([
-          { index: index, fieldName: "name", errorMessage: "" },
+          { index, fieldName: "name", errorMessage: "" },
         ]);
       }
       return;
@@ -46,19 +46,19 @@ const useNodeDetailLogic = (
     if (name === "value") {
       if (value === null || value === "") {
         handleFieldValidationErrorsChange([
-          { index: index, fieldName: name, errorMessage: "必須項目です" },
+          { index, fieldName: name, errorMessage: "必須項目です" },
         ]);
       } else if (isNaN(Number(value))) {
         handleFieldValidationErrorsChange([
           {
-            index: index,
+            index,
             fieldName: name,
             errorMessage: "数値を入力してください",
           },
         ]);
       } else {
         handleFieldValidationErrorsChange([
-          { index: index, fieldName: name, errorMessage: "" },
+          { index, fieldName: name, errorMessage: "" },
         ]);
       }
       return;
@@ -68,12 +68,12 @@ const useNodeDetailLogic = (
       if (value === "%" && updatedNodeInfo.unit !== "") {
         handleFieldValidationErrorsChange([
           {
-            index: index,
+            index,
             fieldName: "unit",
             errorMessage: "％表示のときは単位を空にしてください",
           },
           {
-            index: index,
+            index,
             fieldName: "valueFormat",
             errorMessage: "％表示のときは単位を空にしてください",
           },
@@ -81,12 +81,12 @@ const useNodeDetailLogic = (
       } else {
         handleFieldValidationErrorsChange([
           {
-            index: index,
+            index,
             fieldName: "unit",
             errorMessage: "",
           },
           {
-            index: index,
+            index,
             fieldName: "valueFormat",
             errorMessage: "",
           },
@@ -99,12 +99,12 @@ const useNodeDetailLogic = (
       if (value !== "" && updatedNodeInfo.valueFormat === "%") {
         handleFieldValidationErrorsChange([
           {
-            index: index,
+            index,
             fieldName: "unit",
             errorMessage: "％表示のときは単位を空にしてください",
           },
           {
-            index: index,
+            index,
             fieldName: "valueFormat",
             errorMessage: "％表示のときは単位を空にしてください",
           },
@@ -112,12 +112,12 @@ const useNodeDetailLogic = (
       } else {
         handleFieldValidationErrorsChange([
           {
-            index: index,
+            index,
             fieldName: "unit",
             errorMessage: "",
           },
           {
-            index: index,
+            index,
             fieldName: "valueFormat",
             errorMessage: "",
           },
@@ -126,7 +126,7 @@ const useNodeDetailLogic = (
       return;
     }
     handleFieldValidationErrorsChange([
-      { index: index, fieldName: name, errorMessage: "" },
+      { index, fieldName: name, errorMessage: "" },
     ]);
   };
 

--- a/app/javascript/hooks/useTreeUpdate.ts
+++ b/app/javascript/hooks/useTreeUpdate.ts
@@ -53,6 +53,7 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
       }
     }
     const json = await response.json();
+    console.log("-----result.json------");
     console.dir(json);
     return keysToCamelCase(json);
   };

--- a/app/javascript/propagateSelectedNodesChangesToTree.ts
+++ b/app/javascript/propagateSelectedNodesChangesToTree.ts
@@ -8,6 +8,18 @@ export default function propagateSelectedNodesChangesToTree(
 ): TreeData {
   const updatedTreeData: TreeData = JSON.parse(JSON.stringify(treeData));
 
+  // selectedLayer.parentNodeIdと同じparentIdを持つノードの配列を取得する
+  const siblingNodes = updatedTreeData.nodes.filter(
+    (n) => n.parentId === selectedLayer.parentNodeId
+  );
+  // siblingNodesには含まれていて、selectedNodesには含まれていないidを持つノードを削除する
+  siblingNodes.forEach((node) => {
+    if (!selectedNodes.find((n) => n.id === node.id)) {
+      const index = updatedTreeData.nodes.findIndex((n) => n.id === node.id);
+      updatedTreeData.nodes.splice(index, 1);
+    }
+  });
+
   selectedNodes.forEach((node) => {
     if (node.id === undefined || node.id === null) {
       updatedTreeData.nodes.push(node);

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -4,7 +4,7 @@ class Node < ApplicationRecord
   enum :value_format, { 'なし': 0, '%': 1, '千': 2, '万': 3 }
 
   belongs_to :tree
-  belongs_to :parent, class_name: 'Node', optional: true
+  belongs_to :parent, class_name: 'Node', optional: true, inverse_of: :children
   has_one :child_layer, class_name: 'Layer', foreign_key: 'parent_node_id', dependent: :destroy,
                         inverse_of: :parent_node
   has_many :children, class_name: 'Node', foreign_key: 'parent_id', dependent: :destroy, inverse_of: :parent

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -5,7 +5,8 @@ class Node < ApplicationRecord
 
   belongs_to :tree
   belongs_to :parent, class_name: 'Node', optional: true
-  has_one :child_layer, class_name: 'Layer', dependent: :destroy
+  has_one :child_layer, class_name: 'Layer', foreign_key: 'parent_node_id', dependent: :destroy,
+                        inverse_of: :parent_node
   has_many :children, class_name: 'Node', foreign_key: 'parent_id', dependent: :destroy, inverse_of: :parent
 
   validates :name, presence: true

--- a/spec/support/expect_helper.rb
+++ b/spec/support/expect_helper.rb
@@ -24,6 +24,10 @@ module ExpectHelper
     expect_operation_display(node_svg:, operation:) if operation.present?
   end
 
+  def node_details
+    all(:xpath, "//*[starts-with(@id, 'node-detail-')]")
+  end
+
   private
 
   def expect_selector(index, attribute, value)


### PR DESCRIPTION
close #163 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/163

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 階層内の要素数が3つ以上のときのみ、要素削除のためのメニューを表示するようにした
- ツリー編集画面のツールエリアで各ノードのメニューから「要素を削除」をクリックすると、該当の要素が表示されなくなり、ツールエリア上で要素数のインデックスと計算式が更新されるようにした
- 更新ボタンを押すと、更新がDBに反映され、ノードが削除されるようにした


※その他

- 計算式で表示している要素のidを、要素1,2,3…の表示に合わせて1始まりに変更した。
- それに伴ってcalclation-member-xでidを指定しているテストの該当箇所を修正した。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する（localhostでなく127.0.0.1 だとGoogleログインができないので注意）
3. Googleアカウントでログインしたユーザーでツリーを作成 or 既存のツリーのユーザーをログインしたユーザーに変更する
4. ツリー編集画面にアクセスし、要素が3つ以上ある階層の任意の要素をクリックしてツールエリアを開く
5. 削除したい要素の要素詳細の右上からメニューを開き、「要素を削除」をクリック
6. 更新ボタンをクリック
7. 要素が削除されていることを確認する


<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

メニュー内に「要素を削除」ボタンは存在するが、機能しない状態

### 変更後

![スクリーンショット 2023-08-24 20 22 30](https://github.com/peno022/kpi-tree-generator/assets/40317050/f43b94d7-31de-4e72-b85b-2a204d0fbf8e)

要素が削除されている：

![スクリーンショット 2023-08-24 20 22 47](https://github.com/peno022/kpi-tree-generator/assets/40317050/1f4aa7ff-75bd-4d60-9550-a43041752b8e)