### PR TITLE
階層の削除機能

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,4 +32,8 @@ RSpec/ExampleLength:
 # 1つのexampleで複数のアサーションを許可する
 RSpec/MultipleExpectations:
   Enabled: true
-  Max: 10 # default: 1
+  Max: 15 # default: 1
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: true
+  Max: 10 # default: 5

--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -16,17 +16,13 @@ module Api
     end
 
     def update
-      assign_nodes_attributes
-      assign_layers_attributes
-      initial_nodes_to_delete = extract_initial_nodes_to_delete
-      exclude_objects_to_be_deleted(initial_nodes_to_delete)
-      ActiveRecord::Base.transaction do
-        (@nodes + @layers).each(&:save!)
-        initial_nodes_to_delete.each(&:destroy!)
-        prune_isolated_layers
-      end
+      @tree.update_tree_with_params(tree_params)
       reload_tree
-      render json: { tree: @tree, nodes: @tree.nodes, layers: @tree.layers }, status: :ok
+      render json: {
+        tree: @tree.as_json(except: %i[created_at updated_at]),
+        nodes: @tree.nodes.as_json(except: %i[created_at updated_at]),
+        layers: @tree.layers.as_json(except: %i[created_at updated_at])
+      }, status: :ok
     rescue ActiveRecord::RecordInvalid => e
       render json: { errors: e.record.errors.full_messages, record: e.record }, status: :unprocessable_entity
     end
@@ -42,55 +38,6 @@ module Api
         nodes: %i[id name value value_format unit is_value_locked parent_id tree_id],
         layers: %i[id operation parent_node_id fraction tree_id]
       )
-    end
-
-    def assign_nodes_attributes
-      @nodes = tree_params[:nodes].map do |node_param|
-        node = if node_param[:id]
-                 @tree.nodes.find(node_param[:id])
-               else
-                 Node.new(tree_id: @tree.id)
-               end
-        node.assign_attributes(node_param.slice(:name, :value, :value_format, :unit, :is_value_locked, :parent_id))
-        node
-      end
-    end
-
-    def assign_layers_attributes
-      @layers = tree_params[:layers].map do |layer_param|
-        layer = if layer_param[:id]
-                  @tree.layers.find(layer_param[:id])
-                else
-                  Layer.new(tree_id: @tree.id)
-                end
-        layer.operation = layer_param[:operation]
-        layer.fraction = layer_param[:fraction] || 0
-        layer.parent_node_id = layer_param[:parent_node_id]
-        layer
-      end
-    end
-
-    def exclude_objects_to_be_deleted(initial_nodes_to_delete)
-      nodes_to_delete = initial_nodes_to_delete + gather_descendants(initial_nodes_to_delete)
-      layers_to_delete = @tree.layers.where(parent_node_id: nodes_to_delete.map(&:id))
-      @nodes = @nodes.reject { |node| nodes_to_delete.include?(node) }
-      @layers = @layers.reject { |layer| layers_to_delete.include?(layer) }
-    end
-
-    def extract_initial_nodes_to_delete
-      node_ids_in_params = tree_params[:nodes].pluck(:id).compact
-      @tree.nodes.where.not(id: node_ids_in_params).where.not(id: nil)
-    end
-
-    def gather_descendants(nodes)
-      nodes.flat_map { |node| node.children + gather_descendants(node.children) }
-    end
-
-    def prune_isolated_layers
-      layers_parent_node_ids = @tree.layers.map(&:parent_node_id).uniq.compact
-      nodes_parent_ids = @tree.nodes.map(&:parent_id).uniq.compact
-      # layers_parent_node_idsには含まれていて、nodes_parent_idsには含まれていないparent_node_idを持つLayerを削除する
-      @tree.layers.where(parent_node_id: layers_parent_node_ids - nodes_parent_ids).destroy_all
     end
 
     def reload_tree

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -45,6 +45,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
     fractionErrorMessage,
     handleFieldValidationErrorsChange,
     resetValidationResults,
+    deleteAllNodes,
   } = useLayerToolLogic(selectedNodes, selectedLayer, parentNode);
 
   const isUpdateButtonDisabled = useUpdateButtonStatus(
@@ -98,16 +99,18 @@ const LayerTool: React.FC<LayerToolProps> = ({
             <div className="text-base font-semibold label-operation">
               要素間の関係
             </div>
-            <ToolMenu
-              menuItems={[
-                {
-                  label: "編集中の要素をすべて削除",
-                  onClick: () => {
-                    console.log("編集中の要素をすべて削除");
+            <div className="layer-tool-menu">
+              <ToolMenu
+                menuItems={[
+                  {
+                    label: "選択中の全要素を削除",
+                    onClick: () => {
+                      deleteAllNodes();
+                    },
                   },
-                },
-              ]}
-            />
+                ]}
+              />
+            </div>
           </div>
           <div className="mb-4">
             <Operations

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import NodeDetail from "@/components/trees/tool/nodeDetailArea/NodeDetail";
-import { Layer, NodeFromApi, TreeDataFromApi } from "@/types";
+import { Layer, NodeFromApi, TreeDataFromApi, TreeData } from "@/types";
 import ToolMenu from "@/components/shared/ToolMenu";
 import Operations from "@/components/trees/tool/operationArea/Operations";
 import Calculation from "@/components/trees/tool/calculationArea/Calculation";
@@ -64,13 +64,26 @@ const LayerTool: React.FC<LayerToolProps> = ({
   }, [selectedNodes, selectedLayer, parentNode]);
 
   const saveLayerProperty = async () => {
-    const result = await sendUpdateRequest(
-      propagateSelectedNodesChangesToTree(
+    let newTreeData: TreeData = JSON.parse(JSON.stringify(treeData));
+    if (layerProperty.nodes.length === 0) {
+      // treeDataのnodesからselectedNodesを削除する
+      const newNodes = treeData.nodes.filter((node) => {
+        return !selectedNodes.some((selectedNode) => {
+          return node.id === selectedNode.id;
+        });
+      });
+      newTreeData = {
+        ...newTreeData,
+        nodes: newNodes,
+      };
+    } else {
+      newTreeData = propagateSelectedNodesChangesToTree(
         layerProperty.nodes,
         layerProperty.layer,
         treeData
-      )
-    );
+      );
+    }
+    const result = await sendUpdateRequest(newTreeData);
     if (result) {
       onUpdateSuccess(result);
     }
@@ -88,9 +101,9 @@ const LayerTool: React.FC<LayerToolProps> = ({
             <ToolMenu
               menuItems={[
                 {
-                  label: "階層を削除",
+                  label: "編集中の要素をすべて削除",
                   onClick: () => {
-                    console.log("階層を削除");
+                    console.log("編集中の要素をすべて削除");
                   },
                 },
               ]}
@@ -123,7 +136,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
               handleFieldValidationErrorsChange={
                 handleFieldValidationErrorsChange
               }
-              showToolMenu={layerProperty.nodes.length > 2}
+              isRoot={false}
               deleteNode={deleteNode}
             />
           ))}

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -75,7 +75,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
             handleFieldValidationErrorsChange={
               handleFieldValidationErrorsChange
             }
-            showToolMenu={false}
+            isRoot={true}
             deleteNode={mockDeleteNode}
           />
         </div>

--- a/app/javascript/components/trees/tool/ToolArea.tsx
+++ b/app/javascript/components/trees/tool/ToolArea.tsx
@@ -22,9 +22,10 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
     return <Message text="要素を選択すると、ここに詳細が表示されます。" />;
   }
 
-  const selectedNodes: NodeFromApi[] = allNodes.filter((node) =>
-    selectedNodeIds.includes(node.id)
-  );
+  const selectedNodeIdsSet = new Set(selectedNodeIds);
+  const selectedNodes: NodeFromApi[] = allNodes
+    .filter((node) => selectedNodeIdsSet.has(node.id))
+    .sort((a, b) => a.id - b.id);
 
   if (selectedNodes.length === 0) {
     return (

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -10,7 +10,7 @@ export type NodeDetailProps = {
   handleNodeInfoChange: (index: number, newNodeInfo: Node) => void;
   fieldValidationErrors: FieldValidationErrors;
   handleFieldValidationErrorsChange: (errors: FieldValidationError[]) => void;
-  showToolMenu: boolean;
+  isRoot: boolean;
   deleteNode: (index: number) => void;
 };
 const NodeDetail: React.FC<NodeDetailProps> = ({
@@ -19,7 +19,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
   handleNodeInfoChange,
   fieldValidationErrors,
   handleFieldValidationErrorsChange,
-  showToolMenu,
+  isRoot,
   deleteNode,
 }) => {
   const { handleInputChange } = useNodeDetailLogic(
@@ -37,7 +37,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
       >
         <legend>{`要素${index + 1}`}</legend>
         <div className="absolute right-0 top-2 mt-1.5">
-          {showToolMenu && (
+          {!isRoot && (
             <ToolMenu
               menuItems={[
                 {

--- a/app/javascript/components/trees/tree/CustomNodeButton.tsx
+++ b/app/javascript/components/trees/tree/CustomNodeButton.tsx
@@ -15,11 +15,9 @@ const CustomNodeButton: React.FC<CustomNodeButtonProps> = ({
   const [isHovered, setIsHovered] = React.useState(false);
 
   const handleMouseOut = () => {
-    console.log("CustomNodeButton handleMouseOut");
     setIsHovered(false);
   };
   const handleMouseOver = () => {
-    console.log("CustomNodeButton handleMouseOver");
     setIsHovered(true);
   };
 

--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -116,6 +116,14 @@ const useLayerToolLogic = (
     });
   };
 
+  const deleteAllNodes = () => {
+    setLayerProperty({
+      ...layerProperty,
+      nodes: [],
+    });
+    setFieldValidationErrors([]);
+  };
+
   const [fractionValidation, setFractionValidation] = useState(true);
   const [fractionErrorMessage, setFractionErrorMessage] = useState<
     string | null
@@ -150,6 +158,7 @@ const useLayerToolLogic = (
     fractionErrorMessage,
     handleFieldValidationErrorsChange,
     resetValidationResults,
+    deleteAllNodes,
   };
 };
 

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -5,4 +5,72 @@ class Tree < ApplicationRecord
   has_many :nodes, dependent: :destroy
   has_many :layers, dependent: :destroy
   validates :name, presence: true
+
+  def update_tree_with_params(tree_params)
+    ActiveRecord::Base.transaction do
+      nodes, layers, initial_nodes_to_delete = process_params(tree_params)
+      (nodes + layers).each(&:save!)
+      initial_nodes_to_delete.each(&:destroy!)
+      prune_isolated_layers
+    end
+  end
+
+  private
+
+  def process_params(tree_params)
+    nodes = assign_nodes_attributes(tree_params[:nodes])
+    layers = assign_layers_attributes(tree_params[:layers])
+    initial_nodes_to_delete = extract_initial_nodes_to_delete(tree_params[:nodes])
+    exclude_objects_to_be_deleted(initial_nodes_to_delete, nodes, layers)
+    [nodes, layers, initial_nodes_to_delete]
+  end
+
+  def assign_nodes_attributes(node_params)
+    node_params.map do |node_param|
+      node = if node_param[:id]
+               nodes.find(node_param[:id])
+             else
+               Node.new(tree_id: id)
+             end
+      node.assign_attributes(node_param.slice(:name, :value, :value_format, :unit, :is_value_locked, :parent_id))
+      node
+    end
+  end
+
+  def assign_layers_attributes(layer_params)
+    layer_params.map do |layer_param|
+      layer = if layer_param[:id]
+                layers.find(layer_param[:id])
+              else
+                Layer.new(tree_id: id)
+              end
+      layer.operation = layer_param[:operation]
+      layer.fraction = layer_param[:fraction] || 0
+      layer.parent_node_id = layer_param[:parent_node_id]
+      layer
+    end
+  end
+
+  def exclude_objects_to_be_deleted(initial_nodes_to_delete, nodes, layers)
+    nodes_to_delete = initial_nodes_to_delete + gather_descendants(initial_nodes_to_delete)
+    layers_to_delete = layers.select { |layer| nodes_to_delete.map(&:id).include?(layer.parent_node_id) }
+
+    nodes.reject! { |node| nodes_to_delete.include?(node) }
+    layers.reject! { |layer| layers_to_delete.include?(layer) }
+  end
+
+  def extract_initial_nodes_to_delete(node_params)
+    node_ids_in_params = node_params.pluck(:id).compact
+    nodes.where.not(id: node_ids_in_params).where.not(id: nil)
+  end
+
+  def gather_descendants(nodes)
+    nodes.flat_map { |node| node.children + gather_descendants(node.children) }
+  end
+
+  def prune_isolated_layers
+    layers_parent_node_ids = layers.map(&:parent_node_id).uniq.compact
+    nodes_parent_ids = nodes.map(&:parent_id).uniq.compact
+    layers.where(parent_node_id: layers_parent_node_ids - nodes_parent_ids).destroy_all
+  end
 end

--- a/spec/models/tree_spec.rb
+++ b/spec/models/tree_spec.rb
@@ -3,29 +3,283 @@
 require 'rails_helper'
 
 RSpec.describe Tree do
-  it 'userとnameがあれば有効な状態である' do
-    tree = described_class.new(
-      name: 'My first tree',
-      user: create(:user)
-    )
-    expect(tree).to be_valid
+  describe('バリデーション') do
+    it 'userとnameがあれば有効な状態である' do
+      tree = described_class.new(
+        name: 'My first tree',
+        user: create(:user)
+      )
+      expect(tree).to be_valid
+    end
+
+    it '参照するuserがnilだと無効になる' do
+      tree = described_class.new(user: nil)
+      tree.valid?
+      expect(tree.errors[:user]).to include('must exist')
+    end
+
+    it '存在しないuser_idが設定されると無効になる' do
+      tree = described_class.new(user_id: User.maximum(:id).to_i + 1)
+      tree.valid?
+      expect(tree.errors[:user]).to include('must exist')
+    end
+
+    it 'nameがないと無効になる' do
+      tree = described_class.new(name: nil)
+      tree.valid?
+      expect(tree.errors[:name]).to include("can't be blank")
+    end
   end
 
-  it '参照するuserがnilだと無効になる' do
-    tree = described_class.new(user: nil)
-    tree.valid?
-    expect(tree.errors[:user]).to include('must exist')
-  end
+  describe('update_tree_with_params') do
+    let(:tree) { create(:tree, user: create(:user)) }
+    let!(:root) do
+      create(:node, tree:, name: 'ルート', value: 1000, value_format: '万', unit: '円', is_value_locked: true)
+    end
+    let!(:child1) do
+      create(:node, tree:, name: '子1', value: 5000, value_format: 'なし', unit: '人', is_value_locked: false,
+                    parent: root)
+    end
+    let!(:child2) do
+      create(:node, tree:, name: '子2', value: 2000, value_format: 'なし', unit: '円', is_value_locked: false,
+                    parent: root)
+    end
+    let!(:children_layer) { create(:layer, tree:, operation: 'multiply', fraction: 0, parent_node: root) }
+    let!(:grandchild21) do
+      create(:node, tree:, name: '孫2-1', value: 200, value_format: 'なし', unit: '円', is_value_locked: false,
+                    parent: child2)
+    end
+    let!(:grandchild22) do
+      create(:node, tree:, name: '孫2-2', value: 1000, value_format: 'なし', unit: '円', is_value_locked: false,
+                    parent: child2)
+    end
+    let!(:grandchild23) do
+      create(:node, tree:, name: '孫2-3', value: 800, value_format: 'なし', unit: '円', is_value_locked: false,
+                    parent: child2)
+    end
+    let!(:grand_children_layer) { create(:layer, tree:, operation: 'add', fraction: 0, parent_node: child2) }
+    let!(:tree_params) do
+      {
+        layers: [{
+          id: children_layer.id,
+          operation: children_layer.operation,
+          fraction: children_layer.fraction,
+          parent_node_id: root.id,
+          tree_id: tree.id
+        }, {
+          id: grand_children_layer.id,
+          operation: grand_children_layer.operation,
+          fraction: grand_children_layer.fraction,
+          parent_node_id: child2.id,
+          tree_id: tree.id
+        }],
+        nodes: [
+          {
+            id: root.id,
+            name: root.name,
+            value: root.value,
+            value_format: root.value_format,
+            unit: root.unit,
+            is_value_locked: root.is_value_locked,
+            tree_id: tree.id,
+            parent_id: nil
+          }, {
+            id: child1.id,
+            name: child1.name,
+            value: child1.value,
+            value_format: child1.value_format,
+            unit: child1.unit,
+            is_value_locked: child1.is_value_locked,
+            tree_id: tree.id,
+            parent_id: root.id
+          }, {
+            id: child2.id,
+            name: child2.name,
+            value: child2.value,
+            value_format: child2.value_format,
+            unit: child2.unit,
+            is_value_locked: child2.is_value_locked,
+            tree_id: tree.id,
+            parent_id: root.id
+          }, {
+            id: child2.id,
+            name: child2.name,
+            value: child2.value,
+            value_format: child2.value_format,
+            unit: child2.unit,
+            is_value_locked: child2.is_value_locked,
+            tree_id: tree.id,
+            parent_id: root.id
+          }, {
+            id: grandchild21.id,
+            name: grandchild21.name,
+            value: grandchild21.value,
+            value_format: grandchild21.value_format,
+            unit: grandchild21.unit,
+            is_value_locked: grandchild21.is_value_locked,
+            tree_id: tree.id,
+            parent_id: child2.id
+          }, {
+            id: grandchild22.id,
+            name: grandchild22.name,
+            value: grandchild22.value,
+            value_format: grandchild22.value_format,
+            unit: grandchild22.unit,
+            is_value_locked: grandchild22.is_value_locked,
+            tree_id: tree.id,
+            parent_id: child2.id
+          }, {
+            id: grandchild23.id,
+            name: grandchild23.name,
+            value: grandchild23.value,
+            value_format: grandchild23.value_format,
+            unit: grandchild23.unit,
+            is_value_locked: grandchild23.is_value_locked,
+            tree_id: tree.id,
+            parent_id: child2.id
+          }
+        ]
+      }
+    end
 
-  it '存在しないuser_idが設定されると無効になる' do
-    tree = described_class.new(user_id: User.maximum(:id).to_i + 1)
-    tree.valid?
-    expect(tree.errors[:user]).to include('must exist')
-  end
+    describe('新規追加') do
+      it('既存レイヤーに新規ノードを追加できる') do
+        expect(tree.nodes.count).to eq(6)
+        tree_params[:nodes] << {
+          name: '孫2-4',
+          value: 1000,
+          value_format: 'なし',
+          unit: '円',
+          is_value_locked: false,
+          tree_id: tree.id,
+          parent_id: child2.id
+        }
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(7)
+        expect(tree.nodes.find_by(name: '孫2-4')).to be_present
+        expect(tree.nodes.find_by(name: '孫2-4').parent).to eq(child2)
+      end
 
-  it 'nameがないと無効になる' do
-    tree = described_class.new(name: nil)
-    tree.valid?
-    expect(tree.errors[:name]).to include("can't be blank")
+      it('新規レイヤー・新規ノードを追加できる') do
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        tree_params[:nodes] += [{
+          name: '孫1-1',
+          value: 1000,
+          value_format: 'なし',
+          unit: '人',
+          is_value_locked: false,
+          tree_id: tree.id,
+          parent_id: child1.id
+        }, {
+          name: '孫1-2',
+          value: 4000,
+          value_format: 'なし',
+          unit: '人',
+          is_value_locked: false,
+          tree_id: tree.id,
+          parent_id: child1.id
+        }]
+        tree_params[:layers] << {
+          operation: 'add',
+          fraction: 0,
+          parent_node_id: child1.id,
+          tree_id: tree.id
+        }
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(8)
+        expect(tree.layers.count).to eq(3)
+        expect(tree.nodes.find_by(name: '孫1-1')).to be_present
+        expect(tree.nodes.find_by(name: '孫1-1').parent).to eq(child1)
+        expect(tree.nodes.find_by(name: '孫1-2')).to be_present
+        expect(tree.nodes.find_by(name: '孫1-2').parent).to eq(child1)
+        expect(tree.layers.find_by(operation: 'add', parent_node_id: child1.id)).to be_present
+      end
+    end
+
+    describe('更新') do
+      it('ルートノードを更新できる') do
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        tree_params[:nodes][0][:name] = '更新後ルート'
+        tree_params[:nodes][0][:value] = 20_000
+        tree_params[:nodes][0][:value_format] = '千'
+        tree_params[:nodes][0][:unit] = '円'
+        tree_params[:nodes][0][:is_value_locked] = false
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        expect(tree.nodes.find_by(name: '更新後ルート')).to be_present
+        root_after_updated = tree.nodes.find_by(name: '更新後ルート')
+        expect(root_after_updated.value).to eq(20_000)
+        expect(root_after_updated.value_format).to eq('千')
+        expect(root_after_updated.unit).to eq('円')
+        expect(root_after_updated.is_value_locked).to be(false)
+      end
+
+      it('既存レイヤー・既存ノードを更新できる') do
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        tree_params[:nodes][1][:name] = '更新後子1'
+        tree_params[:nodes][1][:value] = 10_000
+        tree_params[:nodes][1][:value_format] = '万'
+        tree_params[:nodes][1][:unit] = '円'
+        tree_params[:nodes][1][:is_value_locked] = true
+        tree_params[:layers][0][:operation] = 'add'
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        expect(tree.nodes.find_by(name: '更新後子1')).to be_present
+        child1_after_updated = tree.nodes.find_by(name: '更新後子1')
+        expect(child1_after_updated.value).to eq(10_000)
+        expect(child1_after_updated.value_format).to eq('万')
+        expect(child1_after_updated.unit).to eq('円')
+        expect(child1_after_updated.is_value_locked).to be(true)
+        expect(tree.layers.find_by(operation: 'add', parent_node_id: root.id)).to be_present
+      end
+    end
+
+    describe('削除') do
+      it('既存レイヤーから葉ノードを削除できる') do
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        tree_params[:nodes].reject! { |node| node[:name] == '孫2-3' }
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(5)
+        expect(tree.layers.count).to eq(2)
+        expect(tree.nodes.find_by(name: '孫2-3')).to be_nil
+      end
+
+      it('既存レイヤーから非葉ノードと、その子孫レイヤー・ノードを削除できる') do
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        tree_params[:nodes].reject! { |node| node[:name] == '子2' }
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(2)
+        expect(tree.layers.count).to eq(1)
+        expect(tree.nodes.find_by(name: '子2')).to be_nil
+        expect(tree.nodes.find_by(name: '孫2-1')).to be_nil
+        expect(tree.nodes.find_by(name: '孫2-2')).to be_nil
+        expect(tree.nodes.find_by(name: '孫2-3')).to be_nil
+        expect(tree.layers.find_by(parent_node_id: child2.id)).to be_nil
+      end
+
+      it('既存レイヤーとその中の全てのノード、その子孫レイヤー・ノードを削除できる') do
+        expect(tree.nodes.count).to eq(6)
+        expect(tree.layers.count).to eq(2)
+        tree_params[:nodes].reject! { |node| node[:parent_id] == child2.id }
+        tree.update_tree_with_params(tree_params)
+        expect(tree.nodes.count).to eq(3)
+        expect(tree.layers.count).to eq(1)
+        expect(tree.nodes.find_by(name: 'ルート')).to be_present
+        expect(tree.nodes.find_by(name: '子1')).to be_present
+        expect(tree.nodes.find_by(name: '子2')).to be_present
+        expect(tree.layers.find_by(parent_node_id: root.id)).to be_present
+        expect(tree.nodes.find_by(name: '孫2-1')).to be_nil
+        expect(tree.nodes.find_by(name: '孫2-2')).to be_nil
+        expect(tree.nodes.find_by(name: '孫2-3')).to be_nil
+        expect(tree.layers.find_by(parent_node_id: child2.id)).to be_nil
+      end
+    end
   end
 end

--- a/spec/system/trees/tree_show_spec.rb
+++ b/spec/system/trees/tree_show_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Tree pages', js: true do
       expect(page).to have_content('要素を選択すると、ここに詳細が表示されます。')
     end
 
-    it('treeの子ノードをクリックすると、兄弟ノードの色が変わり、ノード詳細が表示される。') do
+    it('treeの子ノードをクリックすると、兄弟ノードの色が変わり、ノード詳細が要素のid順で表示される。') do
       target_node_before = find('g > text', text: '子1').ancestor('g.custom-node')
       sibling_node_before = find('g > text', text: '子2').ancestor('g.custom-node')
       expect(target_node_before.find('rect')[:style]).to include('fill: ghostwhite')
@@ -44,8 +44,8 @@ RSpec.describe 'Tree pages', js: true do
 
       # ツールエリアにクリックしたノードの階層の詳細が表示されていること
       expect(page).to have_content('要素間の関係')
-      expect(page).to have_css('input[value="子1"]')
-      expect(page).to have_css('input[value="子1"]')
+      expect(find_by_id('node-detail-1')).to have_css('input[value="子1"]')
+      expect(find_by_id('node-detail-2')).to have_css('input[value="子2"]')
     end
 
     it('treeのルートノードをクリックすると、ルートノードの色が変わり、ノード詳細が表示される。') do

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -735,11 +735,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         expect(page).not_to have_selector('g > text', text: '孫2-3')
       end
 
-      it('葉ノードでないノードについて、要素を削除ボタンを押してから、更新ボタン→更新するを押すと、ツリーからそのノードが削除される。') do
-        find('g > text', text: '子2').ancestor('g.custom-node').click
-        click_button '要素を追加'
-        find('#updateButton label', text: '更新').click
-        find('.modal-action label', text: '更新する').click
+      it('葉ノードでないノードについて、要素を削除ボタンを押してから、更新ボタン→更新するを押すと、ツリーからそのノードと子孫ノードが削除される。') do
         find('g > text', text: '子2').ancestor('g.custom-node').click
         find_by_id('node-detail-2').find('.tool-menu').click
         click_link '要素を削除'
@@ -749,17 +745,13 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
           name: '子1',
           display_value: '5000人',
           is_value_locked: false,
-          operation: 'multiply',
-          is_leaf: true
-        )
-        expect_tree_node(
-          name: '要素3',
-          display_value: '1',
-          is_value_locked: false,
           operation: '',
           is_leaf: true
         )
         expect(page).not_to have_selector('g > text', text: '子2')
+        expect(page).not_to have_selector('g > text', text: '孫2-1')
+        expect(page).not_to have_selector('g > text', text: '孫2-2')
+        expect(page).not_to have_selector('g > text', text: '孫2-3')
       end
 
       it('葉ノードについて、階層内のすべてのノードを削除できる') do

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -762,6 +762,51 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         expect(page).not_to have_selector('g > text', text: '子2')
       end
 
+      it('葉ノードについて、階層内のすべてのノードを削除できる') do
+        find_by_id('node-detail-3').find('.tool-menu').click
+        click_link '要素を削除'
+        find_by_id('node-detail-2').find('.tool-menu').click
+        click_link '要素を削除'
+        find_by_id('node-detail-1').find('.tool-menu').click
+        click_link '要素を削除'
+        expect(page).not_to have_selector('[id^="node-detail-"]')
+        find('#updateButton label', text: '更新').click
+        find('.modal-action label', text: '更新する').click
+        expect(page).not_to have_selector('g > text', text: '孫2-1')
+        expect(page).not_to have_selector('g > text', text: '孫2-2')
+        expect(page).not_to have_selector('g > text', text: '孫2-3')
+        expect_tree_node(
+          name: '子2',
+          display_value: '2000円',
+          is_value_locked: false,
+          operation: '',
+          is_leaf: true
+        )
+      end
+
+      it('非葉ノードについて、階層内のすべてのノードを削除できる') do
+        find('g > text', text: '子2').ancestor('g.custom-node').click
+        find_by_id('node-detail-2').find('.tool-menu').click
+        click_link '要素を削除'
+        find_by_id('node-detail-1').find('.tool-menu').click
+        click_link '要素を削除'
+        expect(page).not_to have_selector('[id^="node-detail-"]')
+        find('#updateButton label', text: '更新').click
+        find('.modal-action label', text: '更新する').click
+        expect(page).not_to have_selector('g > text', text: '子1')
+        expect(page).not_to have_selector('g > text', text: '子2')
+        expect(page).not_to have_selector('g > text', text: '孫2-1')
+        expect(page).not_to have_selector('g > text', text: '孫2-2')
+        expect(page).not_to have_selector('g > text', text: '孫2-3')
+        expect_tree_node(
+          name: 'ルート',
+          display_value: '1000万円',
+          is_value_locked: true,
+          operation: '',
+          is_leaf: true
+        )
+      end
+
       it('要素を削除ボタンを押して、更新ボタン→更新するを押すと、親ノードの値も計算結果に応じて更新される。') do
         find_by_id('node-detail-3').find('.tool-menu').click
         click_link '要素を削除'

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -667,25 +667,14 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         expect(find_by_id('node-detail-1')).not_to have_css('.tool-menu')
       end
 
-      it('ルートノード以外のノードを選択したとき、ノードが2つの場合は要素のツールメニューが表示されない。') do
+      it('ルートノード以外のノードを選択したとき、要素のツールメニューが表示される。（ノードが2つの場合）') do
         find('g > text', text: '子2').ancestor('g.rd3t-node').click
-        expect(find_by_id('node-detail-1')).not_to have_css('.tool-menu')
-      end
-
-      it('ルートノード以外のノードを選択したとき、ノードが3つ以上ある場合は要素のツールメニューが表示される。') do
-        find('g > text', text: '孫2-3').ancestor('g.rd3t-leaf-node').click
         expect(find_by_id('node-detail-1')).to have_css('.tool-menu')
       end
 
-      it('ノードが3つの状態から1つの要素を削除ボタンを押すと、要素のツールメニューは表示されなくなる。') do
+      it('ルートノード以外のノードを選択したとき、要素のツールメニューが表示される。（ノードが3つ以上の場合）') do
         find('g > text', text: '孫2-3').ancestor('g.rd3t-leaf-node').click
         expect(find_by_id('node-detail-1')).to have_css('.tool-menu')
-        find_by_id('node-detail-3').find('.tool-menu').click
-        click_link '要素を削除'
-        expect(node_details.length).to eq 2
-        node_details.each do |node_detail|
-          expect(node_detail).not_to have_css('.tool-menu')
-        end
       end
     end
 
@@ -747,11 +736,11 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       end
 
       it('葉ノードでないノードについて、要素を削除ボタンを押してから、更新ボタン→更新するを押すと、ツリーからそのノードが削除される。') do
-        find('g > text', text: '子2').ancestor('g.rd3t-node').click
+        find('g > text', text: '子2').ancestor('g.custom-node').click
         click_button '要素を追加'
         find('#updateButton label', text: '更新').click
         find('.modal-action label', text: '更新する').click
-        find('g > text', text: '子2').ancestor('g.rd3t-node').click
+        find('g > text', text: '子2').ancestor('g.custom-node').click
         find_by_id('node-detail-2').find('.tool-menu').click
         click_link '要素を削除'
         find('#updateButton label', text: '更新').click

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
     end
 
     describe('削除を実行') do
-      it('葉ノードについて、要素をを押してから、更新ボタン→更新するを押すと、ツリーからそのノードが削除される。') do
+      it('葉ノードについて、要素を削除ボタンを押してから、更新ボタン→更新するを押すと、ツリーからそのノードが削除される。') do
         find_by_id('node-detail-3').find('.tool-menu').click
         click_link '要素を削除'
         find('#updateButton label', text: '更新').click
@@ -735,26 +735,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         expect(page).not_to have_selector('g > text', text: '孫2-3')
       end
 
-      it('葉ノードでないノードについて、要素を削除ボタンを押してから、更新ボタン→更新するを押すと、ツリーからそのノードと子孫ノードが削除される。') do
-        find('g > text', text: '子2').ancestor('g.custom-node').click
-        find_by_id('node-detail-2').find('.tool-menu').click
-        click_link '要素を削除'
-        find('#updateButton label', text: '更新').click
-        find('.modal-action label', text: '更新する').click
-        expect_tree_node(
-          name: '子1',
-          display_value: '5000人',
-          is_value_locked: false,
-          operation: '',
-          is_leaf: true
-        )
-        expect(page).not_to have_selector('g > text', text: '子2')
-        expect(page).not_to have_selector('g > text', text: '孫2-1')
-        expect(page).not_to have_selector('g > text', text: '孫2-2')
-        expect(page).not_to have_selector('g > text', text: '孫2-3')
-      end
-
-      it('葉ノードについて、階層内のすべてのノードを削除できる') do
+      it('階層内のノードが全て葉ノードのとき、階層内のすべてのノードを削除できる') do
         find_by_id('node-detail-3').find('.tool-menu').click
         click_link '要素を削除'
         find_by_id('node-detail-2').find('.tool-menu').click
@@ -776,12 +757,70 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
         )
       end
 
-      it('非葉ノードについて、階層内のすべてのノードを削除できる') do
+      it('階層内のノードが全て葉ノードのとき、「選択中の全要素を削除」ボタンを押してから更新を実行すると、階層内のすべてのノードを削除できる') do
+        find('.layer-tool-menu').click
+        click_link '選択中の全要素を削除'
+        expect(page).not_to have_selector('[id^="node-detail-"]')
+        find('#updateButton label', text: '更新').click
+        find('.modal-action label', text: '更新する').click
+        expect(page).not_to have_selector('g > text', text: '孫2-1')
+        expect(page).not_to have_selector('g > text', text: '孫2-2')
+        expect(page).not_to have_selector('g > text', text: '孫2-3')
+        expect_tree_node(
+          name: '子2',
+          display_value: '2000円',
+          is_value_locked: false,
+          operation: '',
+          is_leaf: true
+        )
+      end
+
+      it('非葉ノードについて、要素を削除ボタンを押してから、更新ボタン→更新するを押すと、ツリーからそのノードと子孫ノードが削除される。') do
+        find('g > text', text: '子2').ancestor('g.custom-node').click
+        find_by_id('node-detail-2').find('.tool-menu').click
+        click_link '要素を削除'
+        find('#updateButton label', text: '更新').click
+        find('.modal-action label', text: '更新する').click
+        expect_tree_node(
+          name: '子1',
+          display_value: '5000人',
+          is_value_locked: false,
+          operation: '',
+          is_leaf: true
+        )
+        expect(page).not_to have_selector('g > text', text: '子2')
+        expect(page).not_to have_selector('g > text', text: '孫2-1')
+        expect(page).not_to have_selector('g > text', text: '孫2-2')
+        expect(page).not_to have_selector('g > text', text: '孫2-3')
+      end
+
+      it('階層内に非葉ノードが含まれるとき、階層内のすべてのノードを削除でき、一緒に子孫のノードも削除される') do
         find('g > text', text: '子2').ancestor('g.custom-node').click
         find_by_id('node-detail-2').find('.tool-menu').click
         click_link '要素を削除'
         find_by_id('node-detail-1').find('.tool-menu').click
         click_link '要素を削除'
+        expect(page).not_to have_selector('[id^="node-detail-"]')
+        find('#updateButton label', text: '更新').click
+        find('.modal-action label', text: '更新する').click
+        expect(page).not_to have_selector('g > text', text: '子1')
+        expect(page).not_to have_selector('g > text', text: '子2')
+        expect(page).not_to have_selector('g > text', text: '孫2-1')
+        expect(page).not_to have_selector('g > text', text: '孫2-2')
+        expect(page).not_to have_selector('g > text', text: '孫2-3')
+        expect_tree_node(
+          name: 'ルート',
+          display_value: '1000万円',
+          is_value_locked: true,
+          operation: '',
+          is_leaf: true
+        )
+      end
+
+      it('階層内に非葉ノードが含まれるとき、「選択中の全要素を削除」ボタンを押してから更新を実行すると階層内のノードがすべて削除され、一緒に子孫のノードも削除される。') do
+        find('g > text', text: '子2').ancestor('g.custom-node').click
+        find('.layer-tool-menu').click
+        click_link '選択中の全要素を削除'
         expect(page).not_to have_selector('[id^="node-detail-"]')
         find('#updateButton label', text: '更新').click
         find('.modal-action label', text: '更新する').click


### PR DESCRIPTION
close #167 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/167

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 階層の削除（＝階層内の要素をすべて削除すること）ができるようにした
- 画面上では要素をすべて削除する形で、サーバー側で残された階層オブジェクトも削除する
- 1つ1つの要素を削除して結果的に階層内のすべての要素を削除するか、階層の右上メニューから「選択中の全要素を削除」を選択して削除することができる

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する（localhostでなく127.0.0.1 だとGoogleログインができないので注意）
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ツリー編集画面にアクセスし、任意の葉ノードをクリックしてツールエリアを開き、その階層の全ノードが削除できることを確認。1つ1つのノードを削除する方法と、右上メニューから「選択中の全要素を削除」をクリックして更新する方法があるので両方確認する。
5. 任意の非葉ノードをクリックしてツールエリアを開き、その階層の全ノードが削除できることを確認。同じく1つ1つのノードを削除する方法と、右上メニューから「選択中の全要素を削除」をクリックして更新する方法があるので両方確認する。


<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

表示だけしていて機能が無かった削除ボタンの機能を実装したPRなので、変更前スクリーンショットは割愛。

### 変更後
1つ1つの要素を削除していき、更新を実行する方法
要素2を削除：
![スクリーンショット 2023-09-01 23 07 45](https://github.com/peno022/kpi-tree-generator/assets/40317050/31997e6d-d5cd-4c55-9eb8-fa117a5d88e2)

要素1を削除：
![スクリーンショット 2023-09-01 23 07 57](https://github.com/peno022/kpi-tree-generator/assets/40317050/14f1f0b0-7733-4f92-9890-c0c5ab5d81f0)

更新を実行：
![スクリーンショット 2023-09-01 23 08 20](https://github.com/peno022/kpi-tree-generator/assets/40317050/51718570-3bed-4fc8-a6e0-3e14022c39ca)

階層が削除されている：
![スクリーンショット 2023-09-01 23 08 30](https://github.com/peno022/kpi-tree-generator/assets/40317050/ef856604-0ae4-45ab-9b37-d98014e867e0)

階層の右上「選択中の全要素を削除」を使うことも可能。
![スクリーンショット 2023-09-01 23 08 55](https://github.com/peno022/kpi-tree-generator/assets/40317050/cea1e685-0633-4126-8483-8d876edcb5cc)
