### PR TITLE
ツールエリアでノード名を編集し、更新を実行していない状態でツリー上の任意のノードをホバーすると、編集がリセットされてしまうバグを修正

### DIFF
--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -53,7 +53,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             type="text"
             name="name"
             label="名前"
-            value={node.name}
+            value={node.name ?? ""}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationErrors.name === ""}
             errorMessage={fieldValidationErrors.name}
@@ -63,7 +63,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             type="text"
             name="unit"
             label="単位"
-            value={node.unit}
+            value={node.unit ?? ""}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationErrors.unit === ""}
             errorMessage={fieldValidationErrors.unit}
@@ -75,7 +75,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             type="text"
             name="value"
             label="数値"
-            value={node.value}
+            value={node.value ?? ""}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationErrors.value === ""}
             errorMessage={fieldValidationErrors.value}
@@ -85,7 +85,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             type="dropdown"
             name="valueFormat"
             label="表示形式"
-            value={node.valueFormat}
+            value={node.valueFormat ?? "なし"}
             handleInputChange={handleInputChange}
             isValidField={fieldValidationErrors.valueFormat === ""}
             errorMessage={fieldValidationErrors.valueFormat}
@@ -96,7 +96,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
               type="checkbox"
               name="isValueLocked"
               label="数値を自動更新しない"
-              checked={node.isValueLocked}
+              checked={node.isValueLocked ?? false}
               handleInputChange={handleInputChange}
               isValidField={fieldValidationErrors.isValueLocked === ""}
               errorMessage={fieldValidationErrors.isValueLocked}

--- a/app/javascript/components/trees/tree/TreeArea.tsx
+++ b/app/javascript/components/trees/tree/TreeArea.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
 import { selectNodes } from "@/selectNodes";
 import Tree from "react-d3-tree";
@@ -20,9 +20,6 @@ export type TreeAreaProps = {
   treeData: TreeDataFromApi;
   selectedNodeIds: number[];
   handleClick: TreeNodeEventCallback;
-  hoveredNodeId: number | null;
-  handleMouseOver: TreeNodeEventCallback;
-  handleMouseOut: TreeNodeEventCallback;
   onUpdateSuccess: (
     updatedTreeData: TreeDataFromApi,
     selectedNodeIds?: number[]
@@ -33,12 +30,10 @@ export const TreeArea: React.FC<TreeAreaProps> = ({
   treeData,
   selectedNodeIds,
   handleClick,
-  hoveredNodeId,
-  handleMouseOver,
-  handleMouseOut,
   onUpdateSuccess,
 }) => {
   const { errorMessage, sendUpdateRequest } = useTreeUpdate(treeData.tree.id);
+  const [hoveredNodeId, setHoveredNodeId] = useState<number | null>(null);
 
   let rawNodeDatum: WrappedRawNodeDatum;
   rawNodeDatum = convertNodesToRawNodeDatum(treeData.nodes, treeData.layers);
@@ -79,6 +74,20 @@ export const TreeArea: React.FC<TreeAreaProps> = ({
         .map((node) => node.id);
       onUpdateSuccess(result, newNodeIds);
     }
+  };
+
+  const handleMouseOver: TreeNodeEventCallback = (node) => {
+    const hoveredNode = treeData.nodes.find(
+      (nodeData) => nodeData.id === node.data?.attributes?.id
+    );
+    if (!hoveredNode) {
+      return;
+    }
+    setHoveredNodeId(hoveredNode.id);
+  };
+
+  const handleMouseOut: TreeNodeEventCallback = () => {
+    setHoveredNodeId(null);
   };
 
   const CustomNodeWrapper: RenderCustomNodeElementFn = (rd3tNodeProps) => {

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -18,7 +18,6 @@ const EditTreePage = () => {
   });
   const [selectedNodeIds, setSelectedNodeIds] = useState<number[]>([]);
   const [isLoading, setisLoading] = useState(true);
-  const [hoveredNodeId, setHoveredNodeId] = useState<number | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -34,7 +33,7 @@ const EditTreePage = () => {
       }
     };
     load();
-  }, []);
+  }, [treeId]);
 
   if (isLoading) return <>ロード中…</>;
 
@@ -66,20 +65,6 @@ const EditTreePage = () => {
     setSelectedNodeIds(selectedNodeIds);
   };
 
-  const handleMouseOver: TreeNodeEventCallback = (node) => {
-    const hoveredNode = treeData.nodes.find(
-      (nodeData) => nodeData.id === node.data?.attributes?.id
-    );
-    if (!hoveredNode) {
-      return;
-    }
-    setHoveredNodeId(hoveredNode.id);
-  };
-
-  const handleMouseOut: TreeNodeEventCallback = () => {
-    setHoveredNodeId(null);
-  };
-
   return (
     <>
       <div className="flex w-full">
@@ -96,9 +81,6 @@ const EditTreePage = () => {
               treeData={treeData}
               selectedNodeIds={selectedNodeIds}
               handleClick={handleClick}
-              hoveredNodeId={hoveredNodeId}
-              handleMouseOver={handleMouseOver}
-              handleMouseOut={handleMouseOut}
               onUpdateSuccess={handleUpdateSuccess}
             />
           </ErrorBoundary>

--- a/spec/javascript/components/trees/tree/TreeArea.spec.tsx
+++ b/spec/javascript/components/trees/tree/TreeArea.spec.tsx
@@ -14,9 +14,6 @@ describe.skip("ツリーの表示", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [],
         handleClick,
-        hoveredNodeId: null,
-        handleMouseOver: jest.fn(),
-        handleMouseOut: jest.fn(),
         onUpdateSuccess: jest.fn(),
       };
       const { container } = render(<TreeArea {...props} />);

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -298,6 +298,23 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', js: tru
       find('label[for="updateLayerModal"]', text: 'キャンセル').click
       expect(page).not_to have_css('.modal-box')
     end
+
+    it('項目を編集してからツリー上で任意のノードをホバーしても、ツールエリアの表示は変わらない') do
+      find_by_id('node-detail-1').find('input[name="name"]').set('変更後のノード名1')
+      click_button 'たし算'
+      find('g.custom-node', text: '子1').hover
+      expect(find_by_id('node-detail-1').find('input[name="name"]').value).to eq '変更後のノード名1'
+      expect(page).to have_button('たし算', class: 'bg-base-100 border border-neutral')
+    end
+
+    it('項目を編集してからツリー上で任意のノードをクリックすると、編集内容は失われてクリックしたノードを含む階層の情報でツールエリアが表示される') do
+      find_by_id('node-detail-1').find('input[name="name"]').set('変更後のノード名1')
+      click_button 'たし算'
+      find('g.custom-node', text: '子1').click
+      expect(find_by_id('node-detail-1').find('input[name="name"]').value).not_to eq '変更後のノード名1'
+      expect(find_by_id('node-detail-1').find('input[name="name"]').value).to eq '子1'
+      expect(page).to have_button('かけ算', class: 'bg-base-100 border border-neutral')
+    end
   end
 
   describe('選択した階層の更新を、祖先ノードにも反映') do


### PR DESCRIPTION
close #199 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/199

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツールエリアでノード名を編集し、更新を実行していない状態でツリー上の任意のノードをホバーすると、編集がリセットされてしまうバグを修正した。
- EditTreePageコンポーネントでhoveredNodeIdをstateとして持っているから、ノードをホバーするとEditTreePageコンポーネントが再レンダリングされる→その子コンポーネントであるToolAreaコンポーネントも再レンダリングされる→inputの入力値が初期値に戻る、という状態になっていたことが原因。
- hoveredNodeIdはToolAreaコンポーネント内でしか使っていないので、ToolAreaコンポーネントのstateとして持つように修正した。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する（localhostでなく127.0.0.1 だとGoogleログインができないので注意）
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ツリー編集画面にアクセスし、ノードをクリックしてツールエリアを開き、なんらか編集する
5. 更新ボタンを押さずに、任意のノードをホバーする。編集した内容が失われていないことを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![Google Chrome - KPI Tree Generator 2023年-09月-03日 12 06 32](https://github.com/peno022/kpi-tree-generator/assets/40317050/370e1646-ef99-4889-83bb-34efc8dca8e3)


### 変更後

![Google Chrome - KPI Tree Generator 2023年-09月-03日 12 05 12](https://github.com/peno022/kpi-tree-generator/assets/40317050/b66c711d-5a63-4753-9130-4a61e76c7868)

