### PR TITLE
APIにログインユーザーのチェックを入れる＆リクエストスペックを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,7 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Enabled: true
   Max: 10 # default: 5
+
+RSpec/ContextWording:
+  AllowedPatterns:
+    - とき$

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,6 +2,13 @@
 
 module Api
   class BaseController < ApplicationController
-    # TODO: 認証の処理を書く
+    include SessionsHelper
+    before_action :check_logged_in
+
+    def check_logged_in
+      return if current_user
+
+      render json: { errors: [I18n.t('alert.require_login')] }, status: :unauthorized
+    end
   end
 end

--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -3,10 +3,9 @@
 module Api
   class TreesController < BaseController
     before_action :set_tree, only: %i[show update]
+    before_action :ensure_tree_belongs_to_current_user, only: %i[show update]
 
     def show
-      render json: { error: 'Not Found' }, status: :not_found and return unless @tree.user_id == current_user.id
-
       @nodes = @tree.nodes
       @layers = @tree.layers
     end
@@ -41,6 +40,10 @@ module Api
     def reload_tree
       @tree.nodes.reload
       @tree.layers.reload
+    end
+
+    def ensure_tree_belongs_to_current_user
+      render json: { error: 'Not Found' }, status: :not_found and return unless @tree.user_id == current_user.id
     end
   end
 end

--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -6,8 +6,8 @@ module Api
     before_action :ensure_tree_belongs_to_current_user, only: %i[show update]
 
     def show
-      @nodes = @tree.nodes
-      @layers = @tree.layers
+      @nodes = @tree.nodes.order(:id)
+      @layers = @tree.layers.order(:id)
     end
 
     def update
@@ -15,8 +15,8 @@ module Api
       reload_tree
       render json: {
         tree: @tree.as_json(except: %i[created_at updated_at]),
-        nodes: @tree.nodes.as_json(except: %i[created_at updated_at]),
-        layers: @tree.layers.as_json(except: %i[created_at updated_at])
+        nodes: @tree.nodes.order(:id).as_json(except: %i[created_at updated_at]),
+        layers: @tree.layers.order(:id).as_json(except: %i[created_at updated_at])
       }, status: :ok
     rescue ActiveRecord::RecordInvalid => e
       render json: { errors: e.record.errors.full_messages, record: e.record }, status: :unprocessable_entity

--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -5,14 +5,10 @@ module Api
     before_action :set_tree, only: %i[show update]
 
     def show
-      tree = Tree.find(params[:id])
-      if tree.user_id == current_user.id
-        @tree = tree
-        @nodes = @tree.nodes
-        @layers = @tree.layers
-      else
-        render status: :not_found
-      end
+      render json: { error: 'Not Found' }, status: :not_found and return unless @tree.user_id == current_user.id
+
+      @nodes = @tree.nodes
+      @layers = @tree.layers
     end
 
     def update
@@ -31,6 +27,8 @@ module Api
 
     def set_tree
       @tree = Tree.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: 'Not Found' }, status: :not_found and return
     end
 
     def tree_params

--- a/spec/requests/trees_api_spec.rb
+++ b/spec/requests/trees_api_spec.rb
@@ -3,22 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe 'TreesApi' do
-  describe 'GET /api/trees/:id' do
-    context 'ログインしていないとき' do
-      it '401エラーを返すこと' do
-        tree = create(:tree)
-        get "/api/trees/#{tree.id}.json"
-        expect(response).to have_http_status(:unauthorized)
-      end
+  describe 'ログインしていないとき' do
+    it 'GET /api/trees/:id は401エラーを返すこと' do
+      tree = create(:tree)
+      get "/api/trees/#{tree.id}.json"
+      expect(response).to have_http_status(:unauthorized)
     end
 
-    context 'ログイン済みのとき' do
-      let(:user) { User.find_or_create_from_auth_hash(OmniAuth.config.mock_auth[:google_oauth2]) }
+    it 'PUT /api/trees/:id は401エラーを返すこと' do
+      tree = create(:tree)
+      put "/api/trees/#{tree.id}.json", params: { tree: { nodes: [], layers: [] } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 
-      before do
-        get '/auth/google_oauth2/callback'
-      end
+  describe 'GET /api/trees/:id' do
+    let!(:user) { User.find_or_create_from_auth_hash(OmniAuth.config.mock_auth[:google_oauth2]) }
 
+    before do
+      get '/auth/google_oauth2/callback'
+    end
+
+    describe '異常系' do
       it 'ログイン済みで、存在しないツリー（ID=0）の場合は404エラーを返すこと' do
         get '/api/trees/0.json'
         expect(response).to have_http_status(:not_found)
@@ -29,11 +35,169 @@ RSpec.describe 'TreesApi' do
         get "/api/trees/#{tree.id}.json"
         expect(response).to have_http_status(:not_found)
       end
+    end
 
+    describe '正常系' do
       it 'ログインユーザーのツリーの情報を返すこと' do
         tree = create(:tree, user_id: user.id)
         get "/api/trees/#{tree.id}.json"
         expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'PUT /api/trees/:id' do
+    let!(:user) { User.find_or_create_from_auth_hash(OmniAuth.config.mock_auth[:google_oauth2]) }
+
+    before do
+      get '/auth/google_oauth2/callback'
+    end
+
+    describe '異常系' do
+      it 'ログイン済みで、存在しないツリー（ID=0）の場合は404エラーを返すこと' do
+        put '/api/trees/0.json', params: { tree: { nodes: [], layers: [] } }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'ログインユーザーのツリーでない場合は404エラーを返すこと' do
+        tree = create(:tree)
+        put "/api/trees/#{tree.id}.json", params: { tree: { nodes: [], layers: [] } }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it '不正なパラメータを送信した場合、422エラーを返すこと' do
+        tree = create(:tree, user_id: user.id)
+        root = create(:node, tree_id: tree.id, parent_id: nil)
+        invalid_data = { tree: { nodes: [{
+          id: root.id,
+          name: nil, # 不正なパラメータ
+          value: 1000,
+          value_format: '万',
+          unit: '円',
+          is_value_locked: true,
+          tree_id: tree.id,
+          parent_id: nil
+        }], layers: [] } }
+        put "/api/trees/#{tree.id}.json", params: invalid_data
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['errors']).to eq(["Name can't be blank"])
+      end
+    end
+
+    describe '正常系' do
+      let!(:tree) { create(:tree, user_id: user.id) }
+      let!(:root) { create(:node, tree_id: tree.id, parent_id: nil) }
+      let!(:child1) { create(:node, tree_id: tree.id, parent_id: root.id) }
+      let!(:child2) { create(:node, tree_id: tree.id, parent_id: root.id) }
+      let!(:children_layer) { create(:layer, tree_id: tree.id, parent_node_id: root.id) }
+      let!(:body_data) do
+        { tree: { nodes: [{
+          id: root.id,
+          name: 'ルート',
+          value: 1000,
+          value_format: '万',
+          unit: '円',
+          is_value_locked: true,
+          tree_id: tree.id,
+          parent_id: nil
+        }, {
+          id: child1.id,
+          name: '子1',
+          value: 10_000,
+          value_format: 'なし',
+          unit: '人',
+          is_value_locked: false,
+          tree_id: tree.id,
+          parent_id: root.id
+        }, {
+          id: child2.id,
+          name: '子2',
+          value: 1000,
+          value_format: 'なし',
+          unit: '円',
+          is_value_locked: true,
+          tree_id: tree.id,
+          parent_id: root.id
+        }], layers: [
+          {
+            id: children_layer.id,
+            operation: 'multiply',
+            fraction: 0,
+            parent_node_id: root.id,
+            tree_id: tree.id
+          }
+        ] } }
+      end
+
+      it 'ログインユーザーのツリーの情報を更新すること' do
+        put "/api/trees/#{tree.id}.json", params: body_data
+        expected = {
+          'tree' => { 'id' => tree.id, 'name' => tree.name, 'user_id' => tree.user_id },
+          'nodes' => body_data[:tree][:nodes].map do |node|
+            node.transform_keys(&:to_s).tap do |n|
+              n['value'] = n['value'].to_f if n.key?('value')
+            end
+          end,
+          'layers' => body_data[:tree][:layers].map do |layer|
+            layer.transform_keys(&:to_s).tap do |l|
+              l['fraction'] = l['fraction'].to_f if l.key?('fraction')
+            end
+          end
+        }
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq(expected)
+        expect(tree.nodes.count).to eq(3)
+        expect(tree.layers.count).to eq(1)
+      end
+
+      it('ツリーに新規ノード・階層を追加できること') do
+        expect(tree.nodes.count).to eq(3)
+        expect(tree.layers.count).to eq(1)
+
+        new_grandchildren = [{
+          name: '孫1-1',
+          value: 2000,
+          value_format: 'なし',
+          unit: '人',
+          is_value_locked: true,
+          tree_id: tree.id,
+          parent_id: child1.id
+        }, {
+          name: '孫1-2',
+          value: 8000,
+          value_format: 'なし',
+          unit: '人',
+          is_value_locked: false,
+          tree_id: tree.id,
+          parent_id: child1.id
+        }]
+        new_layer = {
+          operation: 'add',
+          fraction: 0,
+          parent_node_id: child1.id,
+          tree_id: tree.id
+        }
+
+        new_body_data = { tree: { nodes: body_data[:tree][:nodes] + new_grandchildren,
+                                  layers: body_data[:tree][:layers] + [new_layer] } }
+        put "/api/trees/#{tree.id}.json", params: new_body_data
+
+        expect(response).to have_http_status(:ok)
+        expect(tree.nodes.count).to eq(5)
+        expect(tree.layers.count).to eq(2)
+      end
+
+      it('ツリーのノード・階層を削除できること') do
+        expect(tree.nodes.count).to eq(3)
+        expect(tree.layers.count).to eq(1)
+
+        new_body_data = { tree: { nodes: [body_data[:tree][:nodes][0]],
+                                  layers: [body_data[:tree][:layer]] } }
+        put "/api/trees/#{tree.id}.json", params: new_body_data
+
+        expect(response).to have_http_status(:ok)
+        expect(tree.nodes.count).to eq(1)
+        expect(tree.layers.count).to eq(0)
       end
     end
   end

--- a/spec/requests/trees_api_spec.rb
+++ b/spec/requests/trees_api_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'TreesApi' do
+  describe 'GET /api/trees/:id' do
+    context 'ログインしていないとき' do
+      it '401エラーを返すこと' do
+        tree = create(:tree)
+        get "/api/trees/#{tree.id}.json"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'ログイン済みのとき' do
+      let(:user) { User.find_or_create_from_auth_hash(OmniAuth.config.mock_auth[:google_oauth2]) }
+
+      before do
+        get '/auth/google_oauth2/callback'
+      end
+
+      it 'ログイン済みで、存在しないツリー（ID=0）の場合は404エラーを返すこと' do
+        get '/api/trees/0.json'
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'ログインユーザーのツリーでない場合は404エラーを返すこと' do
+        tree = create(:tree)
+        get "/api/trees/#{tree.id}.json"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'ログインユーザーのツリーの情報を返すこと' do
+        tree = create(:tree, user_id: user.id)
+        get "/api/trees/#{tree.id}.json"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue

close #181 
close #183 

- https://github.com/peno022/kpi-tree-generator/issues/181
- https://github.com/peno022/kpi-tree-generator/issues/183

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- APIにログインユーザーかどうかのチェック処理を追加した
- ツリーデータ取得時に、ログインユーザーのツリーかどうかのチェック処理を追加した
- 返却データの順番を統一するため、ID昇順でデータを返却するように修正した
- リクエストスペック（`spec/requests/trees_api_spec.rb` ）を作成した

## 動作確認方法

`bundle exec rspec spec/requests/trees_api_spec.rb`がパスする。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

画面には変更がないので割愛。
