### PR TITLE
画像ダウンロード機能を実装

### DIFF
--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -118,6 +118,13 @@ const EditTreePage = () => {
   return (
     <>
       <div className="flex w-full">
+        <button
+          className="btn btn-ghost absolute"
+          id="focus"
+          onClick={fitTreeToView}
+        >
+          ツリー全体を表示
+        </button>
         <div
           className="flex-1 ml-1"
           id="treeWrapper"
@@ -127,13 +134,6 @@ const EditTreePage = () => {
           }}
         >
           <ErrorBoundary fallbackRender={fallbackRender}>
-            <button
-              className="btn btn-ghost absolute"
-              id="focus"
-              onClick={fitTreeToView}
-            >
-              ツリー全体を表示
-            </button>
             <TreeArea
               treeData={treeData}
               selectedNodeIds={selectedNodeIds}

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -17,7 +17,7 @@
         | #{@tree.name}
       a.btn.btn-ghost
         i.fa.fa-lg.fa-pencil.mx-1[aria-hidden="true"]
-    a.btn.btn-outline.mx-1
+    a.btn.btn-outline.mx-1 data-action="download-image"
       | 画像ダウンロード
     - if current_user
       - if current_user.image

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "autoprefixer": "^10.4.13",
     "daisyui": "^2.46.1",
     "esbuild": "^0.16.15",
+    "html2canvas": "^1.4.1",
     "list-to-tree": "^2.2.5",
     "node-fetch": "^3.3.1",
     "postcss": "^8.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,6 +3533,7 @@ __metadata:
     eslint-plugin-react: ^7.32.0
     eslint-plugin-react-hooks: ^4.6.0
     eslint-plugin-testing-library: ^5.11.0
+    html2canvas: ^1.4.1
     jest: ^29.4.3
     jest-environment-jsdom: ^29.5.0
     list-to-tree: ^2.2.5
@@ -3817,6 +3818,13 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 15e6400d2d028bf18be4ed97702b11418f8f8779fb8c743251c863b726638d52f69571d4cc1843224da7838abef0949c670bde46936663c45ad078e89fee5c62
   languageName: node
   linkType: hard
 
@@ -4247,6 +4255,15 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"css-line-break@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "css-line-break@npm:2.1.0"
+  dependencies:
+    utrie: ^1.0.2
+  checksum: 37b1fe632b03be7a287cd394cef8b5285666343443125c510df9cfb6a4734a2c71e154ec8f7bbff72d7c339e1e5872989b1c52d86162aed27d6cc114725bb4d0
   languageName: node
   linkType: hard
 
@@ -5903,6 +5920,16 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
+  languageName: node
+  linkType: hard
+
+"html2canvas@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "html2canvas@npm:1.4.1"
+  dependencies:
+    css-line-break: ^2.1.0
+    text-segmentation: ^1.0.3
+  checksum: c134324af57f3262eecf982e436a4843fded3c6cf61954440ffd682527e4dd350e0c2fafd217c0b6f9a455fe345d0c67b4505689796ab160d4ca7c91c3766739
   languageName: node
   linkType: hard
 
@@ -9111,6 +9138,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-segmentation@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "text-segmentation@npm:1.0.3"
+  dependencies:
+    utrie: ^1.0.2
+  checksum: 2e24632d59567c55ab49ac324815e2f7a8043e63e26b109636322ac3e30692cee8679a448fd5d0f0598a345f407afd0e34ba612e22524cf576d382d84058c013
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -9450,6 +9486,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"utrie@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "utrie@npm:1.0.2"
+  dependencies:
+    base64-arraybuffer: ^1.0.2
+  checksum: c96fbb7d4d8855a154327da0b18e39b7511cc70a7e4bcc3658e24f424bb884312d72b5ba777500b8858e34d365dc6b1a921dc5ca2f0d341182519c6b78e280a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

close #115

- https://github.com/peno022/kpi-tree-generator/issues/115

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 「画像ダウンロード」のボタンクリックをトリガーに、ツリーの画面キャプチャを取得してダウンロードする機能を実装した。画像ダウンロードには、[html2canvas](https://github.com/niklasvh/html2canvas)というスクリーンショット用のライブラリを利用した。
- **キャプチャした画像をテストで確認するのは難しそうなのと、確認したい仕様やデータに複数のパターンがあるわけではないので、テストの追加は割愛した。**  `bin/dev`で開発環境を立ち上げ、手動でブラウザ上で動作確認をした（Google Chrome）。
- 画像ダウンロードのためにツリーの全体が画面上に入るように調整する`fitTreeToView`関数を作成したので、それを利用した「ツリー全体を表示」ボタンも追加した。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する（localhostでなく127.0.0.1 だとGoogleログインができないので注意）
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ツリー編集画面にアクセスする（http://localhost:3001/trees/:id/edit）
5. 「画像ダウンロード」ボタンをクリックし、ツリー部分の画面キャプチャがダウンロードされることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

スクリーンショットは割愛。
「画像ダウンロード」ボタンはあるが、クリックしても何も起きない状態。

### 変更後

![スクリーンショット 2023-09-03 21 36 19](https://github.com/peno022/kpi-tree-generator/assets/40317050/98cd4324-9e0b-4418-8eff-e41e0f6b57d6)

`画像ダウンロード`ボタンを押すと下の画像がダウンロードされる：

![tree (17)](https://github.com/peno022/kpi-tree-generator/assets/40317050/7314d0a4-1364-40af-bb53-121c918e90d3)

`ツリー全体を表示`ボタンを押すと、全体が見えるようにツリー表示位置が調整される：

![スクリーンショット 2023-09-03 21 36 27](https://github.com/peno022/kpi-tree-generator/assets/40317050/4b81c51f-5249-492c-9525-6985c512984d)

