### PR TITLE
ツリー全体を表示ボタンを削除

### DIFF
--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -118,13 +118,6 @@ const EditTreePage = () => {
   return (
     <>
       <div className="flex w-full">
-        <button
-          className="btn btn-ghost absolute"
-          id="focus"
-          onClick={fitTreeToView}
-        >
-          ツリー全体を表示
-        </button>
         <div
           className="flex-1 ml-1"
           id="treeWrapper"


### PR DESCRIPTION
## Issue

なし

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー全体表示をしたときに、ズーム範囲が狭まるという副作用があることがわかり、解消が難しかったのでいったんこのボタンは削除した。
画像ダウンロード機能は残す。

この問題はこちらのissueに残しておいた。
- https://github.com/peno022/kpi-tree-generator/issues/204

## 動作確認方法

http://localhost:3001/trees/;id/edit ページから、「ツリー全体表示」のボタンが削除されていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-09-05 9 49 42](https://github.com/peno022/kpi-tree-generator/assets/40317050/0e502515-1cbe-4405-b934-0b773a7d5bb7)

### 変更後

![スクリーンショット 2023-09-05 9 49 25](https://github.com/peno022/kpi-tree-generator/assets/40317050/9660cd54-a3de-4fce-8057-d20de34e49bd)