### PR TITLE
計算不整合の箇所をツリーに表示できるようにする

### DIFF
--- a/app/javascript/components/trees/tool/calculationArea/MessageBubble.tsx
+++ b/app/javascript/components/trees/tool/calculationArea/MessageBubble.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
 
 type Props = {
   diffValue: number;
@@ -15,6 +17,14 @@ const MessageBubble: React.FC<Props> = ({
     <div className="relative bg-base-200 rounded p-1 w-max mt-2.5">
       <div className="absolute top-0 left-2 w-0 h-0 border-l-8 border-r-8 border-b-8 border-t-0 border-transparent border-b-base-200 -translate-y-full"></div>
       <p className="text-error font-semibold">
+        <FontAwesomeIcon
+          icon={faTriangleExclamation}
+          width={30}
+          height={30}
+          style={{
+            color: "#F87272",
+          }}
+        />
         {diffValue > 0
           ? diffValue.toLocaleString()
           : (-diffValue).toLocaleString()}

--- a/app/javascript/components/trees/tree/CustomNode.tsx
+++ b/app/javascript/components/trees/tree/CustomNode.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faLock } from "@fortawesome/free-solid-svg-icons";
+import {
+  faLock,
+  faTriangleExclamation,
+} from "@fortawesome/free-solid-svg-icons";
 import { CustomNodeElementProps } from "react-d3-tree/lib/types/types/common";
 import CustomNodeButton from "./CustomNodeButton";
 export interface CustomNodeProps extends CustomNodeElementProps {
@@ -110,6 +113,20 @@ const CustomNode = ({
       </g>
 
       <g>
+        <g className="inconsistent-value-icon">
+          {nodeDatum.attributes?.hasInconsistentValue && (
+            <FontAwesomeIcon
+              icon={faTriangleExclamation}
+              width={30}
+              height={30}
+              x={-35}
+              y={-37}
+              style={{
+                color: "#F87272",
+              }}
+            />
+          )}
+        </g>
         <text
           x="130"
           y="42"

--- a/app/javascript/convertNodesToRawNodeDatum.ts
+++ b/app/javascript/convertNodesToRawNodeDatum.ts
@@ -22,7 +22,7 @@ export function convertNodesToRawNodeDatum(
   const treeStructureNode = convertNodesListToTree(preparedNodes);
   const rawNodeDatum =
     convertTreeStructureNodeToRawNodeDatum(treeStructureNode);
-    
+
   return rawNodeDatum;
 }
 

--- a/app/javascript/convertNodesToRawNodeDatum.ts
+++ b/app/javascript/convertNodesToRawNodeDatum.ts
@@ -1,5 +1,6 @@
 import * as types from "@/types";
 import LTT from "list-to-tree";
+import calculateParentNodeValue from "@/calculateParentNodeValue";
 
 export {};
 
@@ -9,6 +10,7 @@ type preparedNode = types.NodeFromApi & {
   isSelected: boolean;
   isHovered: boolean;
   isLeaf: boolean;
+  hasInconsistentValue: boolean;
   childLayer?: types.LayerFromApi;
 };
 
@@ -20,9 +22,7 @@ export function convertNodesToRawNodeDatum(
   const treeStructureNode = convertNodesListToTree(preparedNodes);
   const rawNodeDatum =
     convertTreeStructureNodeToRawNodeDatum(treeStructureNode);
-
-  // console.log("--------rawNodeDatum--------");
-  // console.dir(rawNodeDatum, { depth: null });
+    
   return rawNodeDatum;
 }
 
@@ -30,7 +30,7 @@ function prepareNodeProperties(
   nodes: types.NodeFromApi[],
   layers: types.LayerFromApi[]
 ): preparedNode[] {
-  const nodesWithDisplayProperties = addDisplayProperties(nodes);
+  const nodesWithDisplayProperties = addDisplayProperties(nodes, layers);
   const nodesWithChildLayer = addLayerToNode(
     nodesWithDisplayProperties,
     layers
@@ -60,7 +60,10 @@ function convertNodesListToTree(
   return treeStructureNode[0];
 }
 
-function addDisplayProperties(nodes: types.NodeFromApi[]): preparedNode[] {
+function addDisplayProperties(
+  nodes: types.NodeFromApi[],
+  layers: types.LayerFromApi[]
+): preparedNode[] {
   return nodes.map((node) => {
     const nodeWithDisplayProperties = {
       ...node,
@@ -68,19 +71,31 @@ function addDisplayProperties(nodes: types.NodeFromApi[]): preparedNode[] {
       isSelected: false,
       isHovered: false,
       isLeaf: false,
+      hasInconsistentValue: false,
     };
     const parentNode = nodes.find((n) => n.id === node.parentId);
-    if (parentNode) {
-      const childrenNodes = nodes.filter((n) => n.parentId === node.parentId);
-      // childrenNodesの中で一番大きいidを持つノードが自分自身であれば、isLastInLayerをtrueにする
-      const maxId = Math.max(...childrenNodes.map((n) => n.id));
+    const layer = layers.find((l) => l.parentNodeId === node.parentId);
+
+    if (parentNode && layer) {
+      const siblings = nodes.filter((n) => n.parentId === node.parentId);
+      // siblingsの中で一番大きいidを持つノードが自分自身であれば、isLastInLayerをtrueにする
+      const maxId = Math.max(...siblings.map((n) => n.id));
       if (node.id === maxId) {
         nodeWithDisplayProperties.isLastInLayer = true;
       } else {
         nodeWithDisplayProperties.isLastInLayer = false;
       }
+      if (
+        parentNode.value ===
+        calculateParentNodeValue(parentNode, siblings, layer)
+      ) {
+        nodeWithDisplayProperties.hasInconsistentValue = false;
+      } else {
+        nodeWithDisplayProperties.hasInconsistentValue = true;
+      }
     } else {
       nodeWithDisplayProperties.isLastInLayer = true;
+      nodeWithDisplayProperties.hasInconsistentValue = false;
     }
 
     return nodeWithDisplayProperties;
@@ -135,6 +150,7 @@ function convertTreeStructureNodeToRawNodeDatum(
       isLeaf: !!(
         !treeStructureNode.children || treeStructureNode.children.length === 0
       ),
+      hasInconsistentValue: treeStructureNode.hasInconsistentValue,
     },
     children: treeStructureNode.children?.map((child) =>
       convertTreeStructureNodeToRawNodeDatum(child)

--- a/app/javascript/types.d.ts
+++ b/app/javascript/types.d.ts
@@ -46,6 +46,7 @@ export type TreeStructureNode = {
   isSelected: boolean;
   isHovered: boolean;
   isLeaf: boolean;
+  hasInconsistentValue: boolean;
   childLayer?: LayerFromApi;
   parentId: number;
   children: TreeStructureNode[];
@@ -63,7 +64,9 @@ export type WrappedRawNodeDatum = RawNodeDatum & {
     isSelected: boolean;
     isHovered: boolean;
     isLeaf: boolean;
+    hasInconsistentValue: boolean;
   };
+  children?: WrappedRawNodeDatum[];
 };
 
 export type Tree = {

--- a/spec/javascript/convertNodesToRawNodeDatum.spec.ts
+++ b/spec/javascript/convertNodesToRawNodeDatum.spec.ts
@@ -3,8 +3,7 @@
  */
 
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
-import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
-import { LayerFromApi, NodeFromApi } from "@/types";
+import { LayerFromApi, NodeFromApi, WrappedRawNodeDatum } from "@/types";
 import * as fixtures from "@spec/__fixtures__/sampleData";
 
 const {
@@ -22,7 +21,7 @@ describe("convertNodesToRawNodeDatum", () => {
     it("単体ノード1つに対して、1つのRawNodeDatumを返す", () => {
       const nodes: NodeFromApi[] = [parentNode];
       const layers: LayerFromApi[] = [];
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -35,6 +34,7 @@ describe("convertNodesToRawNodeDatum", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: true,
+          hasInconsistentValue: false,
         },
       };
       expect(convertNodesToRawNodeDatum(nodes, layers)).toEqual(expected);
@@ -44,7 +44,7 @@ describe("convertNodesToRawNodeDatum", () => {
     it("子ノードのRawNodeDatumをchildrenに持つRawNodeDatumを返す", () => {
       const nodes: NodeFromApi[] = [parentNode, childNode1, childNode2];
       const layers: LayerFromApi[] = [childLayer];
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -57,6 +57,7 @@ describe("convertNodesToRawNodeDatum", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -72,6 +73,7 @@ describe("convertNodesToRawNodeDatum", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
           },
           {
@@ -87,6 +89,76 @@ describe("convertNodesToRawNodeDatum", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
+            },
+          },
+        ],
+      };
+      expect(convertNodesToRawNodeDatum(nodes, layers)).toEqual(expected);
+    });
+    it("子ノード・子レイヤーの計算結果が親ノードの値と合わない時、子ノード全員のhasInconsistentValueがtrueになる", () => {
+      const inconsistentChild1: NodeFromApi = {
+        ...childNode1,
+        value: 50,
+        valueFormat: "万",
+      };
+      const inconsistentChild2: NodeFromApi = {
+        ...childNode2,
+        value: 60,
+        valueFormat: "万",
+      };
+      const nodes: NodeFromApi[] = [
+        parentNode,
+        inconsistentChild1,
+        inconsistentChild2,
+      ];
+      const layers: LayerFromApi[] = [childLayer];
+      const expected: WrappedRawNodeDatum = {
+        name: parentNode.name,
+        attributes: {
+          id: parentNode.id,
+          value: parentNode.value,
+          valueFormat: parentNode.valueFormat,
+          unit: parentNode.unit,
+          isValueLocked: parentNode.isValueLocked,
+          operation: "",
+          isLastInLayer: true,
+          isSelected: false,
+          isHovered: false,
+          isLeaf: false,
+          hasInconsistentValue: false,
+        },
+        children: [
+          {
+            name: inconsistentChild1.name,
+            attributes: {
+              id: inconsistentChild1.id,
+              value: inconsistentChild1.value,
+              valueFormat: inconsistentChild1.valueFormat,
+              unit: inconsistentChild1.unit,
+              isValueLocked: inconsistentChild1.isValueLocked,
+              operation: childLayer.operation,
+              isLastInLayer: false,
+              isSelected: false,
+              isHovered: false,
+              isLeaf: true,
+              hasInconsistentValue: true,
+            },
+          },
+          {
+            name: inconsistentChild2.name,
+            attributes: {
+              id: inconsistentChild2.id,
+              value: inconsistentChild2.value,
+              valueFormat: inconsistentChild2.valueFormat,
+              unit: inconsistentChild2.unit,
+              isValueLocked: inconsistentChild2.isValueLocked,
+              operation: childLayer.operation,
+              isLastInLayer: true,
+              isSelected: false,
+              isHovered: false,
+              isLeaf: true,
+              hasInconsistentValue: true,
             },
           },
         ],
@@ -104,7 +176,7 @@ describe("convertNodesToRawNodeDatum", () => {
         grandChildNode2,
       ];
       const layers: LayerFromApi[] = [childLayer, grandChildLayer];
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -117,6 +189,7 @@ describe("convertNodesToRawNodeDatum", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -132,6 +205,7 @@ describe("convertNodesToRawNodeDatum", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: false,
+              hasInconsistentValue: false,
             },
             children: [
               {
@@ -147,6 +221,7 @@ describe("convertNodesToRawNodeDatum", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
               {
@@ -162,6 +237,7 @@ describe("convertNodesToRawNodeDatum", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
             ],
@@ -179,6 +255,7 @@ describe("convertNodesToRawNodeDatum", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
           },
         ],

--- a/spec/javascript/selectNodes.spec.ts
+++ b/spec/javascript/selectNodes.spec.ts
@@ -3,8 +3,7 @@
  */
 
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
-import { RawNodeDatum } from "react-d3-tree/lib/types/types/common";
-import { NodeFromApi, LayerFromApi } from "@/types";
+import { NodeFromApi, LayerFromApi, WrappedRawNodeDatum } from "@/types";
 import * as fixtures from "@spec/__fixtures__/sampleData";
 import { selectNodes } from "@/selectNodes";
 
@@ -31,7 +30,7 @@ describe("selectNodes", () => {
   describe("クリックしたノードが兄弟ノードを持たないノードの場合", () => {
     it("クリックしたノードのみが選択される", () => {
       const result = selectNodes(parentNode.id, rawNodeDatum);
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -44,6 +43,7 @@ describe("selectNodes", () => {
           isSelected: true,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -59,6 +59,7 @@ describe("selectNodes", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: false,
+              hasInconsistentValue: false,
             },
             children: [
               {
@@ -74,6 +75,7 @@ describe("selectNodes", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
               {
@@ -89,6 +91,7 @@ describe("selectNodes", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
             ],
@@ -106,6 +109,7 @@ describe("selectNodes", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
           },
         ],
@@ -116,7 +120,7 @@ describe("selectNodes", () => {
   describe("クリックしたノードが兄弟ノードを持つノードの場合", () => {
     it("クリックしたノードとその兄弟ノードが選択される", () => {
       const result = selectNodes(childNode1.id, rawNodeDatum);
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -129,6 +133,7 @@ describe("selectNodes", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -144,6 +149,7 @@ describe("selectNodes", () => {
               isSelected: true,
               isHovered: false,
               isLeaf: false,
+              hasInconsistentValue: false,
             },
             children: [
               {
@@ -159,6 +165,7 @@ describe("selectNodes", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
               {
@@ -174,6 +181,7 @@ describe("selectNodes", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
             ],
@@ -191,6 +199,7 @@ describe("selectNodes", () => {
               isSelected: true,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
           },
         ],
@@ -202,7 +211,7 @@ describe("selectNodes", () => {
     it("クリックしたノードが選択済みの場合、選択されたままになる", () => {
       const firstSelected = selectNodes(childNode1.id, rawNodeDatum);
       const result = selectNodes(childNode1.id, firstSelected);
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -215,6 +224,7 @@ describe("selectNodes", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -230,6 +240,7 @@ describe("selectNodes", () => {
               isSelected: true,
               isHovered: false,
               isLeaf: false,
+              hasInconsistentValue: false,
             },
             children: [
               {
@@ -245,6 +256,7 @@ describe("selectNodes", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
               {
@@ -260,6 +272,7 @@ describe("selectNodes", () => {
                   isSelected: false,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
             ],
@@ -277,6 +290,7 @@ describe("selectNodes", () => {
               isSelected: true,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
           },
         ],
@@ -286,7 +300,7 @@ describe("selectNodes", () => {
     it("クリックしたノードが選択されていない場合、選択される。前回選択されていたノードの選択は解除される", () => {
       const firstSelected = selectNodes(childNode1.id, rawNodeDatum);
       const result = selectNodes(grandChildNode1.id, firstSelected);
-      const expected: RawNodeDatum = {
+      const expected: WrappedRawNodeDatum = {
         name: parentNode.name,
         attributes: {
           id: parentNode.id,
@@ -299,6 +313,7 @@ describe("selectNodes", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -314,6 +329,7 @@ describe("selectNodes", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: false,
+              hasInconsistentValue: false,
             },
             children: [
               {
@@ -329,6 +345,7 @@ describe("selectNodes", () => {
                   isSelected: true,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
               {
@@ -344,6 +361,7 @@ describe("selectNodes", () => {
                   isSelected: true,
                   isHovered: false,
                   isLeaf: true,
+                  hasInconsistentValue: false,
                 },
               },
             ],
@@ -361,6 +379,7 @@ describe("selectNodes", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
           },
         ],

--- a/spec/javascript/updateAttributeByIds.spec.ts
+++ b/spec/javascript/updateAttributeByIds.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { updateAttributeByIds } from "@/updateAttributeByIds";
 import { WrappedRawNodeDatum } from "@/types";
 
@@ -15,6 +19,7 @@ describe("updateAttributeByIds", () => {
       isSelected: false,
       isHovered: false,
       isLeaf: false,
+      hasInconsistentValue: false,
     },
     children: [
       {
@@ -30,6 +35,7 @@ describe("updateAttributeByIds", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: true,
+          hasInconsistentValue: false,
         },
         children: [],
       },
@@ -46,6 +52,7 @@ describe("updateAttributeByIds", () => {
           isSelected: false,
           isHovered: false,
           isLeaf: false,
+          hasInconsistentValue: false,
         },
         children: [
           {
@@ -61,6 +68,7 @@ describe("updateAttributeByIds", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
             children: [],
           },
@@ -77,6 +85,7 @@ describe("updateAttributeByIds", () => {
               isSelected: false,
               isHovered: false,
               isLeaf: true,
+              hasInconsistentValue: false,
             },
             children: [],
           },

--- a/spec/support/expect_helper.rb
+++ b/spec/support/expect_helper.rb
@@ -9,18 +9,15 @@ module ExpectHelper
     expect_value_locked(index, is_value_locked)
   end
 
-  def expect_tree_node(name:, display_value:, is_value_locked:, is_leaf:, operation: nil)
+  def expect_tree_node(name:, display_value:, is_value_locked:, is_leaf:, operation: nil, has_inconsistent_value: false)
     node_svg = if is_leaf
                  find('g > text', text: name).ancestor('g.rd3t-leaf-node')
                else
                  find('g > text', text: name).ancestor('g.rd3t-node')
                end
     expect(node_svg).to have_text(display_value)
-    if is_value_locked
-      expect(node_svg).to have_css('svg.fa-lock')
-    else
-      expect(node_svg).not_to have_css('svg.fa-lock')
-    end
+    expect_locked_icon(node_svg:, is_value_locked:)
+    expect_inconsisten_value_icon(node_svg:, has_inconsistent_value:)
     expect_operation_display(node_svg:, operation:) if operation.present?
   end
 
@@ -50,6 +47,22 @@ module ExpectHelper
       expect(node_svg).to have_text('＋').and have_no_text('×')
     else
       expect(node_svg).to have_no_text('×').and have_no_text('＋')
+    end
+  end
+
+  def expect_locked_icon(node_svg:, is_value_locked:)
+    if is_value_locked
+      expect(node_svg).to have_css('svg.fa-lock')
+    else
+      expect(node_svg).not_to have_css('svg.fa-lock')
+    end
+  end
+
+  def expect_inconsisten_value_icon(node_svg:, has_inconsistent_value:)
+    if has_inconsistent_value
+      expect(node_svg).to have_css('g.inconsistent-value-icon')
+    else
+      expect(node_svg).not_to have_css('g.inconsistent-value-icon')
     end
   end
 end

--- a/spec/system/trees/tree_show_spec.rb
+++ b/spec/system/trees/tree_show_spec.rb
@@ -105,5 +105,22 @@ RSpec.describe 'Tree pages', js: true do
         index: 2, name: '子2', value: '2000', value_format: 'なし', unit: '円', is_value_locked: false
       )
     end
+
+    it('親ノードとの数値が合っていない階層は、！アイコンが各ノードとツールエリアに表示される') do
+      tree = create(:tree, user: User.find_by(uid: '1234'))
+      root = create(:node, name: 'ルート', value: 1000, unit: '円', tree:)
+      create(:node, name: '子1', value: 200, unit: '円', tree:, parent: root)
+      create(:node, name: '子2', value: 700, unit: '円', tree:, parent: root)
+      create(:layer, operation: 'add', parent_node: root, tree:, fraction: 0)
+      visit edit_tree_path(tree)
+      expect_tree_node(name: 'ルート', display_value: '1000円', is_value_locked: false, is_leaf: false,
+                       has_inconsistent_value: false)
+      expect_tree_node(name: '子1', display_value: '200円', is_value_locked: false, is_leaf: true,
+                       has_inconsistent_value: true)
+      expect_tree_node(name: '子2', display_value: '700円', is_value_locked: false, is_leaf: true,
+                       has_inconsistent_value: true)
+      find('g > text', text: '子2').ancestor('g.rd3t-leaf-node').click
+      expect(find('.calculation')).to have_css('svg.fa-triangle-exclamation')
+    end
   end
 end


### PR DESCRIPTION
close #169 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/169

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 親ノードと子ノードの数値が合わない箇所について、子ノードに「！」のアイコンを表示するようにした
- ツールエリアで親ノードとの数値差分を表示している吹き出しにも、同じ「！」のアイコンの表示を追加した
- 「！」のアイコン表示の確認のテストケースの追加と、ツリーのノード表示のexpect_tree_nodeメソッドに！アイコンの表示有無チェックも追加したため、既存のテストケースで影響する箇所を修正した

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がり、welcomeページが表示されることを確認する
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ツリー編集画面にアクセスする（http://localhost:3001/trees/:id/edit）
5. 親ノードの「数値を自動更新しない」にチェックを入れた状態で子ノードの数値を適当に編集し、親ノードの数値と計算が合わない状態にして更新する
6. 計算が合わなくなった子ノードに、ツリー上で「！」アイコンが表示されていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

親ノードとの値に不整合があってもツリー上には何も表示されていない

![スクリーンショット 2023-09-05 19 44 00](https://github.com/peno022/kpi-tree-generator/assets/40317050/62ebdb39-a1c5-43fc-a3b0-6b67b51407fd)

### 変更後

親ノードとの値に不整合があるノードには「！」アイコンが表示される。ツールエリアの吹き出しにも同じアイコンが出る

![スクリーンショット 2023-09-05 19 42 50](https://github.com/peno022/kpi-tree-generator/assets/40317050/76cbc0a8-32f9-4822-ab3f-ab7f11bee131)
![スクリーンショット 2023-09-05 19 42 59](https://github.com/peno022/kpi-tree-generator/assets/40317050/5251e721-04e7-42c4-86a3-0be6947b59e0)

値を更新して整合性が取れるようになると「！」アイコンは非表示になる。

![スクリーンショット 2023-09-05 19 43 19](https://github.com/peno022/kpi-tree-generator/assets/40317050/4bddc196-2767-4a2f-838c-cb2f6bc56289)