### PR TITLE
ツリーの更新実行中にローディング要素を表示する

### DIFF
--- a/app/javascript/components/shared/Loading.tsx
+++ b/app/javascript/components/shared/Loading.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+const Loading: React.FC = () => {
+  return (
+    <div className="flex items-center justify-center h-full w-full absolute top-0 left-0">
+      <div className="flex flex-col items-center justify-center transform -translate-x-1/2 -translate-y-1/2 absolute top-1/3 left-1/2">
+        <div className="loading loading-spinner loading-lg mb-4"></div>
+        <div className="text-xl">Loading...</div>
+      </div>
+    </div>
+  );
+};
+
+export default Loading;

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -17,6 +17,7 @@ type LayerToolProps = {
   parentNode: NodeFromApi;
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
   treeData: TreeDataFromApi;
+  onUpdateStatusChange: (isUpdating: boolean) => void;
 };
 
 const LayerTool: React.FC<LayerToolProps> = ({
@@ -25,10 +26,10 @@ const LayerTool: React.FC<LayerToolProps> = ({
   parentNode,
   onUpdateSuccess,
   treeData,
+  onUpdateStatusChange,
 }) => {
-  const { errorMessage, sendUpdateRequest, setErrorMessage } = useTreeUpdate(
-    treeData.tree.id
-  );
+  const { errorMessage, sendUpdateRequest, setErrorMessage, isUpdating } =
+    useTreeUpdate(treeData.tree.id);
 
   const {
     layerProperty,
@@ -63,6 +64,10 @@ const LayerTool: React.FC<LayerToolProps> = ({
     resetValidationResults(selectedNodes.length);
     setErrorMessage(null);
   }, [selectedNodes, selectedLayer, parentNode]);
+
+  useEffect(() => {
+    onUpdateStatusChange(isUpdating);
+  }, [isUpdating]);
 
   const saveLayerProperty = async () => {
     let newTreeData: TreeData = JSON.parse(JSON.stringify(treeData));

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import NodeDetail from "@/components/trees/tool/nodeDetailArea/NodeDetail";
 import OpenModalButton from "@/components/shared/OpenModalButton";
 import { NodeFromApi, TreeDataFromApi } from "@/types";
@@ -11,16 +11,17 @@ type RootNodeToolProps = {
   selectedRootNode: NodeFromApi;
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
   treeData: TreeDataFromApi;
+  onUpdateStatusChange: (isUpdating: boolean) => void;
 };
 
 const RootNodeTool: React.FC<RootNodeToolProps> = ({
   selectedRootNode,
   treeData,
   onUpdateSuccess,
+  onUpdateStatusChange,
 }) => {
-  const { errorMessage, sendUpdateRequest, setErrorMessage } = useTreeUpdate(
-    treeData.tree.id
-  );
+  const { errorMessage, sendUpdateRequest, setErrorMessage, isUpdating } =
+    useTreeUpdate(treeData.tree.id);
 
   const {
     nodeInfo,
@@ -28,6 +29,10 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
     fieldValidationErrors,
     handleFieldValidationErrorsChange,
   } = useRootNodeToolLogic(selectedRootNode);
+
+  useEffect(() => {
+    onUpdateStatusChange(isUpdating);
+  }, [isUpdating]);
 
   const isUpdateButtonDisabled = useUpdateButtonStatus(
     fieldValidationErrors,

--- a/app/javascript/components/trees/tool/ToolArea.tsx
+++ b/app/javascript/components/trees/tool/ToolArea.tsx
@@ -8,12 +8,14 @@ export type ToolAreaProps = {
   treeData: TreeDataFromApi;
   selectedNodeIds: number[];
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
+  onUpdateStatusChange: (isUpdating: boolean) => void;
 };
 
 export const ToolArea: React.FC<ToolAreaProps> = ({
   treeData,
   selectedNodeIds,
   onUpdateSuccess,
+  onUpdateStatusChange,
 }) => {
   const allNodes = treeData.nodes;
   const allLayers = treeData.layers;
@@ -43,6 +45,7 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
         selectedRootNode={selectedNodes[0]}
         onUpdateSuccess={onUpdateSuccess}
         treeData={treeData}
+        onUpdateStatusChange={onUpdateStatusChange}
       />
     );
   }
@@ -61,6 +64,7 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
         parentNode={parentNode}
         onUpdateSuccess={onUpdateSuccess}
         treeData={treeData}
+        onUpdateStatusChange={onUpdateStatusChange}
       ></LayerTool>
     );
   }

--- a/app/javascript/components/trees/tree/TreeArea.tsx
+++ b/app/javascript/components/trees/tree/TreeArea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { convertNodesToRawNodeDatum } from "@/convertNodesToRawNodeDatum";
 import { selectNodes } from "@/selectNodes";
 import Tree from "react-d3-tree";
@@ -24,6 +24,7 @@ export type TreeAreaProps = {
     updatedTreeData: TreeDataFromApi,
     selectedNodeIds?: number[]
   ) => void;
+  onUpdateStatusChange: (isUpdating: boolean) => void;
 };
 
 export const TreeArea: React.FC<TreeAreaProps> = ({
@@ -31,9 +32,15 @@ export const TreeArea: React.FC<TreeAreaProps> = ({
   selectedNodeIds,
   handleClick,
   onUpdateSuccess,
+  onUpdateStatusChange,
 }) => {
-  const { errorMessage, sendUpdateRequest } = useTreeUpdate(treeData.tree.id);
+  const { errorMessage, sendUpdateRequest, setErrorMessage, isUpdating } =
+    useTreeUpdate(treeData.tree.id);
   const [hoveredNodeId, setHoveredNodeId] = useState<number | null>(null);
+
+  useEffect(() => {
+    onUpdateStatusChange(isUpdating);
+  }, [isUpdating]);
 
   let rawNodeDatum: WrappedRawNodeDatum;
   rawNodeDatum = convertNodesToRawNodeDatum(treeData.nodes, treeData.layers);
@@ -46,6 +53,7 @@ export const TreeArea: React.FC<TreeAreaProps> = ({
   rawNodeDatum = updateAttributeByIds("isHovered", targetNodeIds, rawNodeDatum);
 
   const createNewChildLayerAndNodes = async (parentNodeId: number) => {
+    setErrorMessage(null);
     console.log("createNewChildLayerAndNodes");
     const newChildLayer: Layer = {
       operation: "multiply",

--- a/app/javascript/hooks/useTreeUpdate.ts
+++ b/app/javascript/hooks/useTreeUpdate.ts
@@ -9,13 +9,16 @@ export type TreeUpdateHook = {
   errorMessage: string | null;
   sendUpdateRequest: (treeData: TreeData) => Promise<TreeDataFromApi | null>;
   setErrorMessage: React.Dispatch<React.SetStateAction<string | null>>;
+  isUpdating: boolean;
 };
 
 export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
 
   const sendUpdateRequest = async (treeData: TreeData) => {
     setErrorMessage(null);
+    setIsUpdating(true);
     const treeDataToSave = nullifyParentNodeId(treeData);
     const bodyData = JSON.stringify(
       keysToSnakeCase({
@@ -35,23 +38,28 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
     if (!response.ok) {
       if (response.status === 422) {
         const json = await response.json();
+        setIsUpdating(false);
         setErrorMessage(json.errors.join("／"));
         return null;
       } else if (response.status >= 500) {
+        setIsUpdating(false);
         setErrorMessage(
           "システムエラーが発生しました。時間を置いてもう一度お試しください。"
         );
         return null;
       } else if (response.status >= 400) {
+        setIsUpdating(false);
         window.location.href = "/404.html";
         return null;
       } else {
+        setIsUpdating(false);
         setErrorMessage(
           "システムエラーが発生しました。時間を置いてもう一度お試しください。"
         );
         return null;
       }
     }
+    setIsUpdating(false);
     const json = await response.json();
     return keysToCamelCase(json);
   };
@@ -60,5 +68,6 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
     errorMessage,
     sendUpdateRequest,
     setErrorMessage,
+    isUpdating,
   };
 };

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { FallbackProps } from "react-error-boundary/dist/react-error-boundary";
 import keysToCamelCase from "@/keysToCamelCase";
 import html2canvas from "html2canvas";
+import Loading from "@/components/shared/Loading";
 
 const EditTreePage = () => {
   const treeId = document.getElementById("tree")?.getAttribute("data-tree-id");
@@ -19,6 +20,7 @@ const EditTreePage = () => {
   });
   const [selectedNodeIds, setSelectedNodeIds] = useState<number[]>([]);
   const [isLoading, setisLoading] = useState(true);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   const getTreeSize = () => {
     const svgElement = document.querySelector("#treeWrapper svg");
@@ -85,7 +87,7 @@ const EditTreePage = () => {
     load();
   }, [treeId]);
 
-  if (isLoading) return <>ロード中…</>;
+  if (isLoading) return <Loading></Loading>;
 
   const handleClick: TreeNodeEventCallback = (node) => {
     const clickedNodeId = node.data?.attributes?.id;
@@ -118,6 +120,7 @@ const EditTreePage = () => {
   return (
     <>
       <div className="flex w-full">
+        <div>{isUpdating && <Loading></Loading>}</div>
         <div
           className="flex-1 ml-1"
           id="treeWrapper"
@@ -132,6 +135,7 @@ const EditTreePage = () => {
               selectedNodeIds={selectedNodeIds}
               handleClick={handleClick}
               onUpdateSuccess={handleUpdateSuccess}
+              onUpdateStatusChange={(status: boolean) => setIsUpdating(status)}
             />
           </ErrorBoundary>
           ;
@@ -149,6 +153,7 @@ const EditTreePage = () => {
               treeData={treeData}
               selectedNodeIds={selectedNodeIds}
               onUpdateSuccess={handleUpdateSuccess}
+              onUpdateStatusChange={(status: boolean) => setIsUpdating(status)}
             />
           </ErrorBoundary>
         </div>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@tailwindcss/typography": "^0.5.9",
     "autoprefixer": "^10.4.13",
-    "daisyui": "^2.46.1",
+    "daisyui": "^3.6.5",
     "esbuild": "^0.16.15",
     "html2canvas": "^1.4.1",
     "list-to-tree": "^2.2.5",

--- a/spec/javascript/components/trees/tool/ToolArea.spec.tsx
+++ b/spec/javascript/components/trees/tool/ToolArea.spec.tsx
@@ -54,6 +54,7 @@ describe("ノードが選択されていないとき", () => {
       treeData: fixtures.treeData,
       selectedNodeIds: [],
       onUpdateSuccess: jest.fn(),
+      onUpdateStatusChange: jest.fn(),
     };
     render(<ToolArea {...toolAreaProps} />);
     expect(
@@ -69,6 +70,7 @@ describe("正常なデータでは起きないはずのエラー", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [999999, 9999999],
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(
@@ -89,6 +91,7 @@ describe("正常なデータでは起きないはずのエラー", () => {
         treeData: treeDataWithoutLayers,
         selectedNodeIds: [2, 3],
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(screen.getByText("存在しない階層です。")).toBeInTheDocument();
@@ -103,6 +106,7 @@ describe("選択したノードが子ノードのとき", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
 
@@ -123,6 +127,7 @@ describe("選択したノードが子ノードのとき", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       const { container } = render(<ToolArea {...toolAreaProps} />);
       const calculationDiv = container.querySelector(".calculation");
@@ -146,6 +151,7 @@ describe("選択したノードが子ノードのとき", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(getNodeField(1, "名前")).toHaveValue("子ノード1");
@@ -165,6 +171,7 @@ describe("選択したノードが子ノードのとき", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
 
@@ -178,6 +185,7 @@ describe("選択したノードが子ノードのとき", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
       const updateButton = getUpdateButton();
@@ -192,6 +200,7 @@ describe("選択したノードが子ノードのとき", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
 
@@ -218,6 +227,7 @@ describe("入力値のバリデーション", () => {
       treeData: fixtures.treeData,
       selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
       onUpdateSuccess: jest.fn(),
+      onUpdateStatusChange: jest.fn(),
     };
     render(<ToolArea {...toolAreaProps} />);
   });
@@ -731,6 +741,7 @@ describe("選択したノードがルートノードの時", () => {
         treeData: fixtures.treeData,
         selectedNodeIds: [1],
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       render(<ToolArea {...toolAreaProps} />);
     });

--- a/spec/javascript/components/trees/tree/TreeArea.spec.tsx
+++ b/spec/javascript/components/trees/tree/TreeArea.spec.tsx
@@ -15,6 +15,7 @@ describe.skip("ツリーの表示", () => {
         selectedNodeIds: [],
         handleClick,
         onUpdateSuccess: jest.fn(),
+        onUpdateStatusChange: jest.fn(),
       };
       const { container } = render(<TreeArea {...props} />);
       const nodes = container.querySelectorAll(".rd3t-leaf-node, .rd3t-node");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3521,7 +3521,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.50.0
     "@typescript-eslint/parser": ^5.50.0
     autoprefixer: ^10.4.13
-    daisyui: ^2.46.1
+    daisyui: ^3.6.5
     esbuild: ^0.16.15
     eslint: ^8.44.0
     eslint-config-prettier: ^8.6.0
@@ -4152,20 +4152,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:^1.1.4, color-name@npm:~1.1.4":
+"color-name@npm:^1.1.4, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
-  languageName: node
-  linkType: hard
-
-"color-string@npm:^1.9.0":
-  version: 1.9.1
-  resolution: "color-string@npm:1.9.1"
-  dependencies:
-    color-name: ^1.0.0
-    simple-swizzle: ^0.2.2
-  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
   languageName: node
   linkType: hard
 
@@ -4178,13 +4168,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color@npm:^4.2":
-  version: 4.2.3
-  resolution: "color@npm:4.2.3"
-  dependencies:
-    color-convert: ^2.0.1
-    color-string: ^1.9.0
-  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
+"colord@npm:^2.9":
+  version: 2.9.3
+  resolution: "colord@npm:2.9.3"
+  checksum: 95d909bfbcfd8d5605cbb5af56f2d1ce2b323990258fd7c0d2eb0e6d3bb177254d7fb8213758db56bb4ede708964f78c6b992b326615f81a18a6aaf11d64c650
   languageName: node
   linkType: hard
 
@@ -4267,7 +4254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-selector-tokenizer@npm:^0.8.0":
+"css-selector-tokenizer@npm:^0.8":
   version: 0.8.0
   resolution: "css-selector-tokenizer@npm:0.8.0"
   dependencies:
@@ -4428,18 +4415,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"daisyui@npm:^2.46.1":
-  version: 2.50.0
-  resolution: "daisyui@npm:2.50.0"
+"daisyui@npm:^3.6.5":
+  version: 3.6.5
+  resolution: "daisyui@npm:3.6.5"
   dependencies:
-    color: ^4.2
-    css-selector-tokenizer: ^0.8.0
-    postcss-js: ^4.0.0
+    colord: ^2.9
+    css-selector-tokenizer: ^0.8
+    postcss: ^8
+    postcss-js: ^4
     tailwindcss: ^3
-  peerDependencies:
-    autoprefixer: ^10.0.2
-    postcss: ^8.1.6
-  checksum: 402b6fd711f8fff7f4b7a609052d8bd4310039c5e4161793b3b68d909fee50aa013ceacda691355d83e4e49b590369a4707aebbad62f3417a6727f44faed94d7
+  checksum: ea8a8e9bf41d79a2a18360e41ce9fd84565d8742484d847b60cf2d51e72d3155ac366649c3449fced744fa6187055fd47b3fc23255e162cee5bfa6c1f8f5ae5c
   languageName: node
   linkType: hard
 
@@ -6110,13 +6095,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arrayish@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "is-arrayish@npm:0.3.2"
-  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
-  languageName: node
-  linkType: hard
-
 "is-bigint@npm:^1.0.1":
   version: 1.0.4
   resolution: "is-bigint@npm:1.0.4"
@@ -7491,6 +7469,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "nanoid@npm:3.3.6"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
+  languageName: node
+  linkType: hard
+
 "natural-compare-lite@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare-lite@npm:1.4.0"
@@ -8012,7 +7999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-js@npm:^4.0.0":
+"postcss-js@npm:^4, postcss-js@npm:^4.0.0":
   version: 4.0.1
   resolution: "postcss-js@npm:4.0.1"
   dependencies:
@@ -8076,6 +8063,17 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8":
+  version: 8.4.29
+  resolution: "postcss@npm:8.4.29"
+  dependencies:
+    nanoid: ^3.3.6
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: dd6daa25e781db9ae5b651d9b7bfde0ec6e60e86a37da69a18eb4773d5ddd51e28fc4ff054fbdc04636a31462e6bf09a1e50986f69ac52b10d46b7457cd36d12
   languageName: node
   linkType: hard
 
@@ -8744,15 +8742,6 @@ __metadata:
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
-  languageName: node
-  linkType: hard
-
-"simple-swizzle@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "simple-swizzle@npm:0.2.2"
-  dependencies:
-    is-arrayish: ^0.3.1
-  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #200 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/200

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリーの更新処理実行中は、画面にローディング要素を表示するようにした。
  - isUpdatingのstateをuseTreeUpdateフック内で新たに定義し、更新を実行するコンポーネントでisUpdatingの変更を検知したらEditTreeComponentのイベントハンドラを呼び出してEditTreeComponentのisUpdatingを更新。
- 下記の3つのタイミングで、EditTreePageコンポーネントのisUpdatingのステータスを変更してローディング要素を表示するようになっている。
  - ルートノードの更新を実行
  - 子ノードの更新を実行
  - ツリーに新たな子階層を追加
- 併せて、ツリー編集画面で最初にツリーのデータを読み込むときの表示も同じものに変更した。（今までは「ロード中」という文字のみ表示していた）
- 更新実行中にだけローディングが表示されている、を確認するシステムテストが難しかったので、手動での動作確認と、過去のテストがすべてパスすることをもってテストはOKとした。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がることを確認する
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ツリー編集画面にアクセスする（http://localhost:3001/trees/:id/edit）
5. ツリー編集画面にアクセス後、ツリーが表示されるまでの間に、ローディングのアニメーションと「Loading...」の文字が表示されていることを確認する
6. ルートノードをクリックしてツールエリアを開き、更新を実行すると、更新ボタンクリック後から更新完了までの間に同様のローディングが表示されることを確認する
7. ↑と同様の操作を、子ノードで実行して確認する。
8. ツリー上で新たな子階層を追加した際、↓のアイコンをクリックしてからツリーが再描画されるまでの間はローディングのアニメーションと「Loading...」の文字が表示されていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

更新実行完了時に画面の変化がない：
![Google Chrome - KPI Tree Generator 2023年-09月-06日 9 23 38](https://github.com/peno022/kpi-tree-generator/assets/40317050/ba86dde6-0729-4856-bbf9-e87792999066)


### 変更後

ツリーを最初に読み込んで編集画面を表示するとき：
![Google Chrome - KPI Tree Generator 2023年-09月-06日 9 21 59](https://github.com/peno022/kpi-tree-generator/assets/40317050/ea8930ae-6033-46a5-9689-6361670f1a3e)


更新のとき：
![Google Chrome - KPI Tree Generator 2023年-09月-06日 9 18 12](https://github.com/peno022/kpi-tree-generator/assets/40317050/b45c5136-5f5a-4ea6-b4bc-4f8e6f4a2914)

子階層を追加するとき：
![Google Chrome - KPI Tree Generator 2023年-09月-06日 9 19 10](https://github.com/peno022/kpi-tree-generator/assets/40317050/56777b50-ba64-4330-bd1d-0874679979fe)
