### PR TITLE
ツリー名を編集できるようにする

### DIFF
--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -2,8 +2,8 @@
 
 module Api
   class TreesController < BaseController
-    before_action :set_tree, only: %i[show update]
-    before_action :ensure_tree_belongs_to_current_user, only: %i[show update]
+    before_action :set_tree
+    before_action :ensure_tree_belongs_to_current_user
 
     def show
       @nodes = @tree.nodes.order(:id)
@@ -20,6 +20,15 @@ module Api
       }, status: :ok
     rescue ActiveRecord::RecordInvalid => e
       render json: { errors: e.record.errors.full_messages, record: e.record }, status: :unprocessable_entity
+    end
+
+    def update_name
+      Rails.logger.info "Updating tree name to #{params[:name]}"
+      if @tree.update(name: params[:name])
+        render json: { name: @tree.reload.name }, status: :ok
+      else
+        render json: { errors: @tree.errors.full_messages.join(', ') }, status: :unprocessable_entity
+      end
     end
 
     private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,2 +1,3 @@
 // Entry point for the build script in your package.json
 import "./pages/trees/edit";
+import "./pages/trees/TreeName";

--- a/app/javascript/hooks/useTreeNameUpdate.ts
+++ b/app/javascript/hooks/useTreeNameUpdate.ts
@@ -1,8 +1,4 @@
 import { useState } from "react";
-import { Tree } from "@/types";
-import keysToSnakeCase from "@/keysToSnakeCase";
-import keysToCamelCase from "@/keysToCamelCase";
-import nullifyParentNodeId from "@/nullifyParentNodeId";
 import token from "@/token";
 
 export type TreeNameUpdateHook = {
@@ -12,6 +8,20 @@ export type TreeNameUpdateHook = {
   isUpdating: boolean;
 };
 
+export const patchTreeName = async (name: string, treeId: number) => {
+  const response = await fetch(`/api/trees/${treeId}/update_name.json"`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-Requested-With": "XMLHttpRequest",
+      "X-CSRF-Token": token(),
+    },
+    credentials: "same-origin",
+    body: JSON.stringify({ name }),
+  });
+  return response;
+};
+
 export const useTreeNameUpdate = (treeId: number): TreeNameUpdateHook => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
@@ -19,16 +29,7 @@ export const useTreeNameUpdate = (treeId: number): TreeNameUpdateHook => {
   const sendTreeNameUpdateRequest = async (name: string) => {
     setErrorMessage(null);
     setIsUpdating(true);
-    const response = await fetch(`/api/trees/${treeId}/update_name.json"`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "X-Requested-With": "XMLHttpRequest",
-        "X-CSRF-Token": token(),
-      },
-      credentials: "same-origin",
-      body: JSON.stringify({ name: name }),
-    });
+    const response = await patchTreeName(name, treeId);
     if (!response.ok) {
       if (response.status === 422) {
         const json = await response.json();

--- a/app/javascript/hooks/useTreeNameUpdate.ts
+++ b/app/javascript/hooks/useTreeNameUpdate.ts
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { Tree } from "@/types";
+import keysToSnakeCase from "@/keysToSnakeCase";
+import keysToCamelCase from "@/keysToCamelCase";
+import nullifyParentNodeId from "@/nullifyParentNodeId";
+import token from "@/token";
+
+export type TreeNameUpdateHook = {
+  errorMessage: string | null;
+  setErrorMessage: React.Dispatch<React.SetStateAction<string | null>>;
+  sendTreeNameUpdateRequest: (tree: string) => Promise<string | null>;
+  isUpdating: boolean;
+};
+
+export const useTreeNameUpdate = (treeId: number): TreeNameUpdateHook => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+
+  const sendTreeNameUpdateRequest = async (name: string) => {
+    setErrorMessage(null);
+    setIsUpdating(true);
+    const response = await fetch(`/api/trees/${treeId}/update_name.json"`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Requested-With": "XMLHttpRequest",
+        "X-CSRF-Token": token(),
+      },
+      credentials: "same-origin",
+      body: JSON.stringify({ name: name }),
+    });
+    if (!response.ok) {
+      if (response.status === 422) {
+        const json = await response.json();
+        setIsUpdating(false);
+        setErrorMessage(json.errors.join("／"));
+        return null;
+      } else if (response.status >= 500) {
+        setIsUpdating(false);
+        setErrorMessage(
+          "システムエラーが発生しました。時間を置いてもう一度お試しください。"
+        );
+        return null;
+      } else if (response.status >= 400) {
+        setIsUpdating(false);
+        window.location.href = "/404.html";
+        return null;
+      } else {
+        setIsUpdating(false);
+        setErrorMessage(
+          "システムエラーが発生しました。時間を置いてもう一度お試しください。"
+        );
+        return null;
+      }
+    }
+    setIsUpdating(false);
+    const json = await response.json();
+    return json.name;
+  };
+
+  return {
+    errorMessage,
+    setErrorMessage,
+    sendTreeNameUpdateRequest,
+    isUpdating,
+  };
+};

--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+import { useTreeNameUpdate } from "@/hooks/useTreeNameUpdate";
+
+const TreeName = () => {
+  const treeId = Number(
+    document.getElementById("tree-name")?.getAttribute("data-tree-id")
+  );
+  const treeName = document
+    .getElementById("tree-name")
+    ?.getAttribute("data-tree-name");
+
+  if (!treeId || !treeName || isNaN(treeId)) {
+    return (
+      <div className="text-error">
+        ツリー名の読み込みにエラーが発生しています。画面を再読み込みして再度お試しください。
+      </div>
+    );
+  }
+
+  const [treeNameEditing, setTreeNameEditing] = useState(treeName || "");
+  const [isEditing, setIsEditing] = useState(false);
+  const {
+    errorMessage,
+    setErrorMessage,
+    sendTreeNameUpdateRequest,
+    isUpdating,
+  } = useTreeNameUpdate(treeId);
+
+  const handleTreeNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTreeNameEditing(e.target.value);
+  };
+  const handleTreeNameSubmit = async () => {
+    if (isUpdating) return;
+    if (treeNameEditing === "") {
+      setErrorMessage("ツリー名を入力してください");
+      return;
+    }
+    if (treeNameEditing === treeName) {
+      setIsEditing(false);
+      return;
+    }
+    const updatedName = await sendTreeNameUpdateRequest(treeNameEditing);
+    if (updatedName) {
+      setTreeNameEditing(updatedName);
+      setIsEditing(false);
+    } else {
+      setTreeNameEditing(treeName);
+      setErrorMessage("ツリー名の更新に失敗しました。再度お試しください。");
+    }
+  };
+
+  const handleEditButtonClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancelEditButtonClick = () => {
+    setTreeNameEditing(treeName);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="flex items-center">
+      {isUpdating && <div className="loading loading-spinner mr-2"></div>}
+      {isEditing ? (
+        <>
+          <div className="text-error">{errorMessage}</div>
+          <input
+            type="text"
+            className="input input-bordered input-primary w-full max-w-xs"
+            value={treeNameEditing}
+            onChange={handleTreeNameChange}
+          />
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={handleTreeNameSubmit}
+          >
+            OK
+          </button>
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={handleCancelEditButtonClick}
+          >
+            キャンセル
+          </button>
+        </>
+      ) : (
+        <>
+          <h1 className="text-xl font-bold mr-4">{treeNameEditing}</h1>
+          <button className="btn btn-ghost" onClick={handleEditButtonClick}>
+            <i className="fa fa-lg fa-pencil mx-1" aria-hidden="true"></i>
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("tree-name") as HTMLElement;
+  if (container) {
+    createRoot(container).render(<TreeName />);
+  }
+});

--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { createRoot } from "react-dom/client";
 import { useTreeNameUpdate } from "@/hooks/useTreeNameUpdate";
 
-const TreeName = () => {
+export const TreeName = () => {
   const treeId = Number(
     document.getElementById("tree-name")?.getAttribute("data-tree-id")
   );
@@ -51,10 +51,12 @@ const TreeName = () => {
   };
 
   const handleEditButtonClick = () => {
+    setErrorMessage(null);
     setIsEditing(true);
   };
 
   const handleCancelEditButtonClick = () => {
+    setErrorMessage(null);
     setTreeNameEditing(treeName);
     setIsEditing(false);
   };
@@ -70,15 +72,17 @@ const TreeName = () => {
             className="input input-bordered input-primary w-full max-w-xs"
             value={treeNameEditing}
             onChange={handleTreeNameChange}
+            name="tree-name-input"
+            aria-label="tree-name-input"
           />
           <button
-            className="btn btn-ghost btn-sm"
+            className="btn btn-ghost btn-sm edit-tree-name-ok"
             onClick={handleTreeNameSubmit}
           >
             OK
           </button>
           <button
-            className="btn btn-ghost btn-sm"
+            className="btn btn-ghost btn-sm edit-tree-name-cancel"
             onClick={handleCancelEditButtonClick}
           >
             キャンセル
@@ -87,7 +91,11 @@ const TreeName = () => {
       ) : (
         <>
           <h1 className="text-xl font-bold mr-4">{treeNameEditing}</h1>
-          <button className="btn btn-ghost" onClick={handleEditButtonClick}>
+          <button
+            className="btn btn-ghost edit-tree-name-button"
+            aria-label="Edit tree name"
+            onClick={handleEditButtonClick}
+          >
             <i className="fa fa-lg fa-pencil mx-1" aria-hidden="true"></i>
           </button>
         </>

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -13,10 +13,7 @@
           a
             | 保存
     .flex-grow.flex.justify-center
-      h1.text-xl.font-bold
-        | #{@tree.name}
-      a.btn.btn-ghost
-        i.fa.fa-lg.fa-pencil.mx-1[aria-hidden="true"]
+      #tree-name data-tree-name=@tree.name data-tree-id=@tree.id
     a.btn.btn-outline.mx-1 data-action="download-image"
       | 画像ダウンロード
     - if current_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@
 
 Rails.application.routes.draw do
   namespace 'api' do
-    resources :trees, only: %i[show create update]
+    resources :trees do
+      member do
+        patch 'update_name'
+      end
+    end
   end
   resources :trees, only: %i[index edit destroy]
 

--- a/spec/javascript/components/trees/TreeName.spec.tsx
+++ b/spec/javascript/components/trees/TreeName.spec.tsx
@@ -1,0 +1,283 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { TreeName } from "@/pages/trees/TreeName";
+import { useTreeNameUpdate } from "@/hooks/useTreeNameUpdate";
+
+jest.mock("@/hooks/useTreeNameUpdate", () => ({
+  useTreeNameUpdate: jest.fn(),
+}));
+
+const mockSendTreeNameUpdateRequest = jest.fn();
+
+beforeEach(() => {
+  (useTreeNameUpdate as jest.Mock).mockReturnValue({
+    errorMessage: null,
+    setErrorMessage: jest.fn(),
+    sendTreeNameUpdateRequest: mockSendTreeNameUpdateRequest,
+    isUpdating: false,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+const user = userEvent.setup();
+
+describe("TreeName", () => {
+  describe("初期表示時の異常系", () => {
+    it("treeNameがない時は、エラーメッセージが表示されること。編集ボタンは表示されないこと。", () => {
+      const mockElement = document.createElement("div");
+      mockElement.id = "tree-name";
+      mockElement.setAttribute("data-tree-id", "12345");
+      // treeName をセットしない
+      document.body.appendChild(mockElement);
+
+      render(<TreeName />);
+      expect(document.querySelector(".text-error")).toHaveTextContent(
+        "ツリー名の読み込みにエラーが発生しています。画面を再読み込みして再度お試しください。"
+      );
+    });
+
+    it("treeIdがない時、エラーメッセージが表示されること。編集ボタンは表示されないこと。", () => {
+      const mockElement = document.createElement("div");
+      mockElement.id = "tree-name";
+      // treeId をセットしない
+      mockElement.setAttribute("data-tree-name", "Valid Name");
+      document.body.appendChild(mockElement);
+
+      render(<TreeName />);
+      expect(document.querySelector(".text-error")).toHaveTextContent(
+        "ツリー名の読み込みにエラーが発生しています。画面を再読み込みして再度お試しください。"
+      );
+    });
+
+    it("treeIdが数値でない時、エラーメッセージが表示されること。編集ボタンは表示されないこと。", () => {
+      const mockElement = document.createElement("div");
+      mockElement.id = "tree-name";
+      mockElement.setAttribute("data-tree-id", "invalid-id");
+      mockElement.setAttribute("data-tree-name", "Valid Name");
+      document.body.appendChild(mockElement);
+
+      render(<TreeName />);
+      expect(document.querySelector(".text-error")).toHaveTextContent(
+        "ツリー名の読み込みにエラーが発生しています。画面を再読み込みして再度お試しください。"
+      );
+    });
+
+    it("treeNameが空文字の時、エラーメッセージが表示されること。編集ボタンは表示されないこと。", () => {
+      const mockElement = document.createElement("div");
+      mockElement.id = "tree-name";
+      mockElement.setAttribute("data-tree-id", "12345");
+      mockElement.setAttribute("data-tree-name", "");
+      document.body.appendChild(mockElement);
+
+      render(<TreeName />);
+      expect(document.querySelector(".text-error")).toHaveTextContent(
+        "ツリー名の読み込みにエラーが発生しています。画面を再読み込みして再度お試しください。"
+      );
+    });
+  });
+
+  describe("ツリー名更新実行時の異常系", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="tree-name" data-tree-id="1" data-tree-name="売上ツリー"></div>
+      `;
+    });
+
+    it("ツリー名が変更されていない時、sendTreeNameUpdateRequestが呼ばれずに完了すること", async () => {
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", {
+        name: "Edit tree name",
+      });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const okButton = screen.getByRole("button", { name: "OK" });
+      await act(async () => {
+        await user.click(okButton);
+      });
+      expect(mockSendTreeNameUpdateRequest).not.toHaveBeenCalled();
+      expect(screen.getByText("売上ツリー")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("textbox", {
+          name: "tree-name-input",
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    it.todo("ツリー名の更新に失敗した時、エラーメッセージが表示されること");
+
+    // 下記はuseTreeNameUpdateの実体を利用してシステムテストで確認できている
+    // it.todo(
+    //   "ツリー名が空文字の時、「ツリー名を入力してください」というエラーが表示されること"
+    // );
+    // it.todo(
+    //   "エラーメッセージが表示されている状態で、再度ツリー名の編集をしてOKボタンを押すと、エラーメッセージが消えること"
+    // );
+  });
+
+  describe("正常系", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="tree-name" data-tree-id="1" data-tree-name="売上ツリー"></div>
+      `;
+    });
+
+    it("treeNameと編集ボタンが表示されること", () => {
+      render(<TreeName />);
+      const treeName = screen.getByText("売上ツリー");
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+
+      expect(treeName).toBeInTheDocument();
+      expect(editButton).toBeInTheDocument();
+    });
+
+    it("編集ボタンを押すと、ツリー名が編集可能になること", async () => {
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const treeNameInput = screen.getByRole("textbox", {
+        name: "tree-name-input",
+      });
+      expect(treeNameInput).toBeInTheDocument();
+      await act(async () => {
+        await user.type(treeNameInput, "編集後");
+      });
+      expect(treeNameInput).toHaveValue("売上ツリー編集後");
+    });
+
+    it("編集ボタンを押すと、OKボタンとキャンセルボタンが表示され、編集ボタンは非表示になること", async () => {
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const okButton = screen.getByRole("button", { name: "OK" });
+      const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+      expect(okButton).toBeInTheDocument();
+      expect(cancelButton).toBeInTheDocument();
+      expect(editButton).not.toBeInTheDocument();
+    });
+
+    it("キャンセルボタンを押すと、ツリー名の編集がキャンセルされること", async () => {
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const treeNameInput = screen.getByRole("textbox", {
+        name: "tree-name-input",
+      });
+      await act(async () => {
+        await user.type(treeNameInput, "編集後");
+      });
+      const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+      await act(async () => {
+        await user.click(cancelButton);
+      });
+      expect(treeNameInput).not.toBeInTheDocument();
+      expect(cancelButton).not.toBeInTheDocument();
+      expect(screen.getByText("売上ツリー")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Edit tree name" })
+      ).toBeInTheDocument();
+    });
+
+    it("ツリー名の編集をして、OKボタンを押すと、ツリー名が更新されること", async () => {
+      mockSendTreeNameUpdateRequest.mockResolvedValueOnce("編集後のツリー名");
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const treeNameInput = screen.getByRole("textbox", {
+        name: "tree-name-input",
+      });
+      await act(async () => {
+        await user.type(treeNameInput, "編集後");
+      });
+      const okButton = screen.getByRole("button", { name: "OK" });
+      await act(async () => {
+        await user.click(okButton);
+      });
+      expect(mockSendTreeNameUpdateRequest).toHaveBeenCalledWith(
+        "売上ツリー編集後"
+      );
+      expect(treeNameInput).not.toBeInTheDocument();
+      expect(screen.getByText("編集後のツリー名")).toBeInTheDocument();
+    });
+
+    it("ツリー名の編集をして、OKボタンを押すと、OKボタンとキャンセルボタンが表示されないこと", async () => {
+      mockSendTreeNameUpdateRequest.mockResolvedValueOnce("編集後のツリー名");
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const treeNameInput = screen.getByRole("textbox", {
+        name: "tree-name-input",
+      });
+      await act(async () => {
+        await user.type(treeNameInput, "編集後");
+      });
+      const okButton = screen.getByRole("button", { name: "OK" });
+      await act(async () => {
+        await user.click(okButton);
+      });
+      expect(
+        screen.queryByRole("button", { name: "OK" })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "キャンセル" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("ツリー名の編集をして、OKボタンを押すと、編集ボタンが表示されること", async () => {
+      mockSendTreeNameUpdateRequest.mockResolvedValueOnce("編集後のツリー名");
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const treeNameInput = screen.getByRole("textbox", {
+        name: "tree-name-input",
+      });
+      await act(async () => {
+        await user.type(treeNameInput, "編集後");
+      });
+      const okButton = screen.getByRole("button", { name: "OK" });
+      await act(async () => {
+        await user.click(okButton);
+      });
+      expect(
+        screen.getByRole("button", { name: "Edit tree name" })
+      ).toBeInTheDocument();
+    });
+
+    it("ツリー名の編集をして、OKボタンを押すと、ツリー名の編集が不可になること", async () => {
+      mockSendTreeNameUpdateRequest.mockResolvedValueOnce("編集後のツリー名");
+      render(<TreeName />);
+      const editButton = screen.getByRole("button", { name: "Edit tree name" });
+      await act(async () => {
+        await user.click(editButton);
+      });
+      const treeNameInput = screen.getByRole("textbox", {
+        name: "tree-name-input",
+      });
+      await act(async () => {
+        await user.type(treeNameInput, "編集後");
+      });
+      const okButton = screen.getByRole("button", { name: "OK" });
+      await act(async () => {
+        await user.click(okButton);
+      });
+      expect(treeNameInput).not.toBeInTheDocument();
+    });
+  });
+});

--- a/spec/system/trees/tree_name_update_spec.rb
+++ b/spec/system/trees/tree_name_update_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ツリー名を変更する', js: true, login_required: true do
+  before do
+    visit log_out_path
+    visit root_path
+    click_button 'Googleでログイン'
+
+    tree = create(:tree, user: User.find_by(uid: '1234'), name: '変更前のツリー名')
+    create(:node, name: 'ルート', tree:)
+    visit edit_tree_path(tree)
+  end
+
+  describe '更新に成功する時' do
+    it 'ツリー名を変更できる' do
+      expect(find('h1', text: '変更前のツリー名')).to be_present
+      expect(find('.edit-tree-name-button')).to be_present
+      expect(page).not_to have_css('.edit-tree-name-ok')
+      expect(page).not_to have_css('.edit-tree-name-cancel')
+
+      find('.edit-tree-name-button').click
+      expect(page).to have_css('.edit-tree-name-ok')
+      expect(page).to have_css('.edit-tree-name-cancel')
+      expect(page).not_to have_css('.edit-tree-name-button')
+      find('input[name="tree-name-input"]').set('変更後のツリー名')
+      find('.edit-tree-name-ok').click
+
+      expect(find('h1', text: '変更後のツリー名')).to be_present
+      expect(find('.edit-tree-name-button')).to be_present
+      expect(page).not_to have_css('.edit-tree-name-ok')
+      expect(page).not_to have_css('.edit-tree-name-cancel')
+    end
+
+    it 'キャンセルボタンを押すと、名前が変わらないままで完了する' do
+      expect(find('h1', text: '変更前のツリー名')).to be_present
+      find('.edit-tree-name-button').click
+      find('input[name="tree-name-input"]').set('変更後のツリー名')
+      find('.edit-tree-name-cancel').click
+      expect(find('h1', text: '変更前のツリー名')).to be_present
+    end
+
+    it 'ツリー名を変更しないままOKボタンを押すと、名前が変わらないままで完了する' do
+      expect(find('h1', text: '変更前のツリー名')).to be_present
+      find('.edit-tree-name-button').click
+      find('.edit-tree-name-ok').click
+      expect(find('h1', text: '変更前のツリー名')).to be_present
+    end
+  end
+
+  describe '更新に失敗する時' do
+    it 'ツリー名が空の状態でOKボタンを押すと、「ツリー名を入力してください」というエラーが表示される' do
+      find('.edit-tree-name-button').click
+      find('input[name="tree-name-input"]').set('')
+      find('.edit-tree-name-ok').click
+      expect(page).to have_text('ツリー名を入力してください')
+    end
+
+    it 'エラーメッセージが表示された後、キャンセルボタンを押すとエラーが消える' do
+      find('.edit-tree-name-button').click
+      find('input[name="tree-name-input"]').set('')
+      find('.edit-tree-name-ok').click
+      expect(page).to have_text('ツリー名を入力してください')
+      find('.edit-tree-name-cancel').click
+      expect(page).not_to have_text('ツリー名を入力してください')
+      expect(page).not_to have_css('.text-error')
+    end
+
+    it 'エラーメッセージが表示された後、ツリー名を正しく変更しOKボタンを押して更新が完了すると、エラーが消える' do
+      find('.edit-tree-name-button').click
+      find('input[name="tree-name-input"]').set('')
+      find('.edit-tree-name-ok').click
+      expect(page).to have_text('ツリー名を入力してください')
+
+      find('input[name="tree-name-input"]').set('変更後のツリー名')
+      find('.edit-tree-name-ok').click
+      expect(page).not_to have_text('ツリー名を入力してください')
+      expect(page).not_to have_css('.text-error')
+      expect(find('h1', text: '変更後のツリー名')).to be_present
+    end
+  end
+end


### PR DESCRIPTION
close #155

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/155

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- slim上ツリー名表示していた部分をReactコンポーネント化し、ツリー名の編集機能を追加した。
- update_tree_nameのAPI、ルーティングを作成した。
- コンポーネントテスト、リクエストスペック、システムスペックを追加した。
  - コンポーネントテストにおける一部のエラー確認ケースについて、カスタムフックのモックをうまく活用できずに1件TODO状態。コンポーネントテストの理解を深めたのちに対応したい。手動での動作確認は実施済み。

## 動作確認方法


1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がることを確認する
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ツリー編集画面にアクセスする（http://localhost:3001/trees/:id/edit）
5. ツリー名の横の鉛筆ボタンをクリックすると、ツリー名が編集できる状態になり、OKボタンとキャンセルボタンが表示されることを確認する。
6. OKボタンを押すと、編集後のツリー名が表示されることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

ツリー名の横に鉛筆ボタンを配置しているが、クリックしても何も起きない状態。

![スクリーンショット 2023-09-08 20 50 27](https://github.com/peno022/kpi-tree-generator/assets/40317050/a7ac4eba-b514-4669-bfa2-779e55c1d736)


### 変更後

ツリー名の編集ができる。

![Google Chrome - KPI Tree Generator 2023年-09月-08日 20 49 09](https://github.com/peno022/kpi-tree-generator/assets/40317050/7c8cc8dc-621a-48a5-9cf4-94675ddf5743)
