### PR TITLE
ツリー一覧画面を作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'kaminari'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 gem 'rails-i18n', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,18 @@ GEM
       railties (>= 6.0.0)
     json (2.6.3)
     jwt (2.7.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     launchy (2.5.2)
       addressable (~> 2.8)
     loofah (2.19.1)
@@ -318,6 +330,7 @@ DEPENDENCIES
   foreman
   jbuilder
   jsbundling-rails
+  kaminari
   launchy
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,7 @@ class HomeController < ApplicationController
 
   def index
     if current_user
+      @trees = current_user.trees.order(updated_at: :desc).page(params[:page]).per(10)
       render template: 'trees/index'
     else
       render template: 'welcome/index'

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "First" page
+  - available local variables
+    url          : url to the first page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.first
+  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+'

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -5,6 +5,6 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-span.first
-  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
-'
+
+- unless current_page.first?
+  = link_to t('views.pagination.first'), url, remote:, class: 'join-item btn'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,9 @@
+/ Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.page.gap
+  == t('views.pagination.truncate').html_safe
+'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -4,6 +4,6 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-span.page.gap
-  == t('views.pagination.truncate').html_safe
-'
+
+button.join-item.btn.btn-disabled
+  == t('views.pagination.truncate')

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Last" page
+  - available local variables
+    url          : url to the last page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.last
+  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -5,6 +5,6 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-span.last
-  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
-'
+
+- unless current_page.last?
+  = link_to t('views.pagination.last'), url, remote:, class: 'join-item btn'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Next" page
+  - available local variables
+    url          : url to the next page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.next
+  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -5,6 +5,9 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-span.next
-  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
-'
+
+- unless current_page.last?
+  = link_to t('views.pagination.next'), url,
+    rel: 'next',
+    remote:,
+    class: 'join-item btn'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,11 @@
+/ Link showing page number
+  - available local variables
+    page         : a page object for "this" page
+    url          : url to this page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span class="page#{' current' if page.current?}"
+  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -6,6 +6,9 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
-'
+
+- if page.current?
+  span.join-item.btn.btn-active
+    = page
+- else
+  = link_to page, url, { remote:, rel: page.rel, class: 'join-item btn' }

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,19 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination
+    == first_page_tag unless current_page.first?
+    == prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        == page_tag page
+      - elsif !page.was_truncated?
+        == gap_tag
+    == next_page_tag unless current_page.last?
+    == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -7,7 +7,7 @@
     paginator    : the paginator that renders the pagination tags inside
 
 == paginator.render do
-  nav.pagination
+  nav.pagination.join.m-6
     == first_page_tag unless current_page.first?
     == prev_page_tag unless current_page.first?
     - each_page do |page|

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Previous" page
+  - available local variables
+    url          : url to the previous page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.prev
+  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+'

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -5,6 +5,9 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-span.prev
-  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
-'
+
+- unless current_page.first?
+  = link_to t('views.pagination.previous'), url,
+    rel: 'prev',
+    remote:,
+    class: 'join-item btn'

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -13,9 +13,9 @@
         tbody
           - @trees.each do |tree|
             tr
-              td = link_to tree.name, edit_tree_path(tree)
-              td = tree.updated_at
-              td
+              td.td-tree-name = link_to tree.name, edit_tree_path(tree)
+              td.td-tree-updated-at = tree.updated_at
+              td.td-tree-action
                 button.btn.btn-sm.mr-3
                   = link_to edit_tree_path(tree) do
                     | 編集

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -1,7 +1,31 @@
 = render 'shared/header'
-.container.mx-10
+.container.mx-16
   h1.text-xl
-    | ツリー一覧（仮画面）
-  button.btn.my-3
-    = link_to edit_tree_path(1) do
-      | ツリー1の編集画面へ
+    | ツリー一覧
+  - if @trees.any?
+    .overflow-x-auto.m-3
+      table.table.table-lg
+        thead
+          tr
+            th 名前
+            th 最終更新
+            th
+        tbody
+          - @trees.each do |tree|
+            tr
+              td = link_to tree.name, edit_tree_path(tree)
+              td = tree.updated_at
+              td
+                button.btn.btn-sm.mr-3
+                  = link_to edit_tree_path(tree) do
+                    | 編集
+                button.btn.btn-sm.btn-ghost.mr-3
+                  | 削除
+
+      = paginate @trees
+  - else
+    .text-base.mt-6.mb-4
+      |まだツリーがありません。
+    button.btn.btn-primary.my-2
+      |ツリーを作成する
+    / = link_to 'ツリーを作成する', create_and_edit_trees_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module KpiTreeGenerator
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.generators do |g|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,10 @@
 en:
   alert:
     require_login: Please log in.
+  views:
+    pagination:
+      first: "<< First"
+      last: "Last >>"
+      previous: "< Prev"
+      next: "Next >"
+      truncate: "..."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -207,8 +207,8 @@ ja:
     pm: 午後
   views:
     pagination:
-      first: 最初
-      last: 最後
-      next: 次へ
-      previous: 前へ
+      first: << 最初へ
+      last: 最後へ >>
+      next: 次へ >
+      previous: < 前へ
       truncate: "..."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,3 +205,10 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  views:
+    pagination:
+      first: 最初
+      last: 最後
+      next: 次へ
+      previous: 前へ
+      truncate: "..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       end
     end
   end
-  resources :trees, only: %i[index edit destroy]
+  resources :trees, only: %i[edit destroy]
 
   get 'auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure', to: redirect('/')

--- a/spec/system/require_login_spec.rb
+++ b/spec/system/require_login_spec.rb
@@ -24,12 +24,6 @@ RSpec.describe 'ページごとのログイン要否' do
       expect(page).to have_selector 'h1', text: 'プライバシーポリシー'
     end
 
-    it('ツリー一覧画面にアクセスできず、ウェルカムページにリダイレクトされること') do
-      visit trees_path
-      expect(page).to have_content(I18n.t('alert.require_login'))
-      expect(page).to have_content('KPIツリーを簡単に')
-    end
-
     it('ツリー編集画面にアクセスできず、ウェルカムページにリダイレクトされること') do
       tree = create(:tree)
       visit edit_tree_path(tree)
@@ -48,11 +42,6 @@ RSpec.describe 'ページごとのログイン要否' do
     describe 'ログイン必須の画面' do
       it('ルートにアクセスするとツリー一覧ページが表示されること') do
         visit root_path
-        expect(page).to have_content('ツリー一覧')
-      end
-
-      it('ツリー一覧画面にアクセスできること') do
-        visit trees_path
         expect(page).to have_content('ツリー一覧')
       end
 

--- a/spec/system/trees/trees_index_spec.rb
+++ b/spec/system/trees/trees_index_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ツリー一覧', js: true, login_required: true do
+  let!(:user) { User.find_or_create_from_auth_hash(OmniAuth.config.mock_auth[:google_oauth2]) }
+
+  before do
+    visit log_out_path
+    visit root_path
+    click_button 'Googleでログイン'
+  end
+
+  describe 'ツリーが0件のときの画面' do
+    it('ツリーが0件のときは、テーブルが表示されず、ツリー作成ボタンが表示されること') do
+      visit root_path
+      expect(page).to have_content('まだツリーがありません。')
+      expect(page).to have_button('ツリーを作成する')
+      expect(page).not_to have_table
+    end
+  end
+
+  describe 'ツリーが1件以上存在するときの画面' do
+    let!(:tree_times) { [3.days.ago, 2.days.ago, 1.day.ago] }
+
+    before do
+      tree_times.each_with_index do |time, index|
+        create(:tree, name: "ツリー#{index + 1}", user_id: user.id, updated_at: time)
+      end
+      visit root_path
+    end
+
+    it('ツリーの一覧が表示されること') do
+      expect(page).to have_table
+      expect(page).to have_selector('table > tbody > tr', count: 3)
+      expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー1')
+      expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー2')
+      expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー3')
+      tree_times.reverse.each_with_index do |time, index|
+        formatted_time = time.strftime('%Y-%m-%d %H:%M:%S %z')
+        expect(page).to have_selector("table > tbody > tr:nth-child(#{index + 1}) > td.td-tree-updated-at",
+                                      text: formatted_time)
+      end
+      expect(page).to have_selector('table > tbody > tr > td.td-tree-action > button', text: '編集', count: 3)
+    end
+
+    it('一覧のツリーがupdate_atの降順に並んでいること') do
+      timestamps = page.all('table > tbody > tr > td.td-tree-updated-at').map(&:text)
+      # フォーマット '2023-09-11 14:23:27 +0900' の文字列をDateTimeオブジェクトに変換
+      parsed_timestamps = timestamps.map { |ts| DateTime.strptime(ts, '%Y-%m-%d %H:%M:%S %z') }
+      expect(parsed_timestamps).to eq(parsed_timestamps.sort.reverse)
+    end
+
+    it('ツリー名をクリックすると、そのツリーの編集画面に遷移すること') do
+      most_recent_updated_tree = Tree.order(updated_at: :desc).first
+      page.all('table > tbody > tr > td.td-tree-name > a').first.click
+      expect(page).to have_current_path(edit_tree_path(most_recent_updated_tree))
+    end
+
+    it('編集ボタンをクリックすると、そのツリーの編集画面に遷移すること') do
+      most_recent_updated_tree = Tree.order(updated_at: :desc).first
+      page.all('table > tbody > tr > td.td-tree-action > button', text: '編集').first.click
+      expect(page).to have_current_path(edit_tree_path(most_recent_updated_tree))
+    end
+  end
+
+  describe 'ページネーションの動作' do
+    it('ツリーが10件以下のときはページネーションが表示されないこと') do
+      create(:tree, name: 'ツリー1', user_id: user.id)
+      visit root_path
+      expect(page).not_to have_selector('nav.pagination')
+    end
+
+    it('ツリーが11件以上のときはページネーションが表示されること') do
+      11.times do |i|
+        create(:tree, name: "ツリー#{i + 1}", user_id: user.id)
+      end
+      visit root_path
+      expect(page).to have_selector('nav.pagination')
+    end
+
+    it('ツリーが11件以上のときは、1ページに10件のリストが表示されていること') do
+      11.times do |i|
+        create(:tree, name: "ツリー#{i + 1}", user_id: user.id)
+      end
+      visit root_path
+      expect(page).to have_selector('table > tbody > tr', count: 10)
+    end
+
+    it('ページネーションのNextをクリックすると、ツリー一覧が切り替わること') do
+      create_list(:tree, 31, user_id: user.id).each_with_index do |tree, index|
+        tree.update(name: "ツリー#{index + 1}", updated_at: index.hours.ago)
+      end
+      visit root_path
+      click_link 'Next >'
+      expect(page).to have_selector('table > tbody > tr', count: 10)
+      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー11')
+    end
+
+    it('ページネーションのPreviousをクリックすると、ツリー一覧が切り替わること') do
+      create_list(:tree, 31, user_id: user.id).each_with_index do |tree, index|
+        tree.update(name: "ツリー#{index + 1}", updated_at: index.hours.ago)
+      end
+      visit "#{root_path}?page=2"
+      click_link '< Prev'
+      expect(page).to have_selector('table > tbody > tr', count: 10)
+      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー1')
+    end
+
+    it('ページネーションのFirstをクリックすると、ツリー一覧が切り替わること') do
+      create_list(:tree, 31, user_id: user.id).each_with_index do |tree, index|
+        tree.update(name: "ツリー#{index + 1}", updated_at: index.hours.ago)
+      end
+      visit "#{root_path}?page=3"
+      click_link '<< First'
+      expect(page).to have_selector('table > tbody > tr', count: 10)
+      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー1')
+    end
+
+    it('ページネーションのLastをクリックすると、ツリー一覧が切り替わること') do
+      create_list(:tree, 31, user_id: user.id).each_with_index do |tree, index|
+        tree.update(name: "ツリー#{index + 1}", updated_at: index.hours.ago)
+      end
+      visit root_path
+      click_link 'Last >>'
+      expect(page).to have_selector('table > tbody > tr', count: 1)
+      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー31')
+    end
+  end
+end


### PR DESCRIPTION
close #103 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/103

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ログインしてroot_pathにアクセスするとツリー一覧を表示するようにした
- 一覧のページネーションのためkaminariを導入した
- ログイン時は/と/treesの両方でツリー一覧を表示していたが、/treesはroutesから削除して/のみに統一した

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がることを確認する
3. 既存のツリー1のユーザーをログインしたユーザーに変更する（Googleアカウントでログインしたユーザーのツリーを新規に作成してもOK）
4. ログインし、ホーム画面（＝ツリー一覧）にアクセスする（http://localhost:3001/）
5. ツリー一覧が表示されていることを確認する
6. ツリー名またはそのツリーの編集ボタンをクリックすると、ツリー編集画面に遷移することを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

仮の画面で作ってあった：

![スクリーンショット 2023-09-11 19 58 00](https://github.com/peno022/kpi-tree-generator/assets/40317050/d97924d9-0db8-43da-8ac2-076e919783b5)

### 変更後

ツリー一覧を実装：

![スクリーンショット 2023-09-11 19 57 13](https://github.com/peno022/kpi-tree-generator/assets/40317050/b8bec88d-3347-4817-940e-9817efd66365)