### PR TITLE
ツリーの新規作成機能

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -9,4 +9,19 @@ class TreesController < ApplicationController
       render file: Rails.public_path.join('404.html'), status: :not_found, layout: false, content_type: 'text/html'
     end
   end
+
+  def create_and_edit
+    @tree = Tree.new(name: '新しいツリー', user_id: current_user.id)
+
+    begin
+      ActiveRecord::Base.transaction do
+        @tree.save!
+        @tree.create_default_structure
+      end
+      redirect_to edit_tree_path(@tree)
+    rescue ActiveRecord::RecordInvalid
+      flash[:alert] = I18n.t('custom_errors.messages.tree_create_failed')
+      redirect_to root_path
+    end
+  end
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -15,6 +15,21 @@ class Tree < ApplicationRecord
     end
   end
 
+  def create_default_structure
+    return if nodes.any?
+
+    ActiveRecord::Base.transaction do
+      parent_node = Node.create!(
+        name: '親の要素', value: 100, unit: '円', value_format: '万', is_value_locked: false, tree_id: id
+      )
+      Node.create!(name: '子の要素1', value: 1000, unit: '円', value_format: '万', is_value_locked: false,
+                   parent: parent_node, tree_id: id)
+      Node.create!(name: '子の要素2', value: 10, unit: '', value_format: '%', is_value_locked: false,
+                   parent: parent_node, tree_id: id)
+      Layer.create!(operation: 'multiply', fraction: 0, parent_node:, tree_id: id)
+    end
+  end
+
   private
 
   def process_params(tree_params)

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,4 +1,4 @@
-nav.navbar.bg-base-100
+nav.navbar.bg-base-100.border-b-2.border-base-300
   .flex-1
     a.btn.btn-ghost.normal-case.text-xl
       |KPIツリーメーカー

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -1,7 +1,11 @@
 = render 'shared/header'
-.container.mx-16
-  h1.text-xl
-    | ツリー一覧
+.mx-16.my-8
+  .flex.items-center
+    h1.text-xl.font-bold
+      |ツリー一覧
+    - if @trees.any?
+      = button_to '新規作成', create_and_edit_trees_path, method: :post,
+       class: 'btn btn-sm my-2 ml-10'
   - if @trees.any?
     .overflow-x-auto.m-3
       table.table.table-lg
@@ -26,6 +30,5 @@
   - else
     .text-base.mt-6.mb-4
       |まだツリーがありません。
-    button.btn.btn-primary.my-2
-      |ツリーを作成する
-    / = link_to 'ツリーを作成する', create_and_edit_trees_path
+    = button_to 'ツリーを作成する', create_and_edit_trees_path, method: :post,
+       class: 'btn btn-primary my-2'

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,5 +1,5 @@
 = render 'shared/header'
-.flex.flex-col.min-h-screen.border-t-2.border-b-2.border-base-300
+.flex.flex-col.min-h-screen.border-b-2.border-base-300
   .hero.bg-base-200.flex-grow
     .hero-content.object-center
       .max-w-md

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,6 @@ en:
       previous: "< Prev"
       next: "Next >"
       truncate: "..."
+  custom_errors:
+    messages:
+      tree_create_failed: "The tree failed to create. Please reload the screen and try again."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,3 +212,6 @@ ja:
       next: 次へ >
       previous: < 前へ
       truncate: "..."
+  custom_errors:
+    messages:
+      tree_create_failed: "ツリーの作成に失敗しました。画面を再読み込みしてもう一度お試しください。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,12 @@ Rails.application.routes.draw do
       end
     end
   end
-  resources :trees, only: %i[edit destroy]
+
+  resources :trees, only: %i[edit destroy] do
+    collection do
+      post :create_and_edit
+    end
+  end
 
   get 'auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure', to: redirect('/')

--- a/spec/models/tree_spec.rb
+++ b/spec/models/tree_spec.rb
@@ -282,4 +282,69 @@ RSpec.describe Tree do
       end
     end
   end
+
+  describe('create_default_structure') do
+    let(:user) { create(:user) }
+    let(:tree) { create(:tree, user:) }
+
+    context '既にツリーにノードが存在するとき' do
+      it '何もしないこと' do
+        create(:node, tree:)
+
+        expect do
+          tree.create_default_structure
+        end.not_to change { tree.nodes.count }.from(1)
+        expect(tree.layers).to be_empty
+      end
+    end
+
+    context 'ツリーにノードが存在しないとき' do
+      it '設定したデフォルトのノード・レイヤーを作成すること' do
+        tree.create_default_structure
+        expect(tree.nodes.count).to eq(3)
+        expect(tree.layers.count).to eq(1)
+        parent_node = tree.nodes.find_by(name: '親の要素')
+        expect(parent_node).to be_present
+        expect_node(
+          node: parent_node,
+          value: 100,
+          unit: '円',
+          value_format: '万',
+          is_value_locked: false
+        )
+        child_node1 = tree.nodes.find_by(name: '子の要素1')
+        expect(child_node1).to be_present
+        expect(child_node1.parent).to eq(parent_node)
+        expect_node(
+          node: child_node1,
+          value: 1000,
+          unit: '円',
+          value_format: '万',
+          is_value_locked: false
+        )
+        child_node2 = tree.nodes.find_by(name: '子の要素2')
+        expect(child_node2).to be_present
+        expect(child_node2.parent).to eq(parent_node)
+        expect_node(
+          node: child_node2,
+          value: 10,
+          unit: '',
+          value_format: '%',
+          is_value_locked: false
+        )
+        layer = tree.layers.first
+        expect(layer).to be_present
+        expect(layer.operation).to eq('multiply')
+        expect(layer.fraction).to eq(0)
+        expect(layer.parent_node).to eq(parent_node)
+      end
+    end
+  end
+end
+
+def expect_node(node:, value:, unit:, value_format:, is_value_locked:)
+  expect(node.value).to eq(value)
+  expect(node.unit).to eq(unit)
+  expect(node.value_format).to eq(value_format)
+  expect(node.is_value_locked).to be(is_value_locked)
 end

--- a/spec/system/trees/tree_create_spec.rb
+++ b/spec/system/trees/tree_create_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ツリーを新規作成する', js: true, login_required: true do
+  let!(:user) { User.find_or_create_from_auth_hash(OmniAuth.config.mock_auth[:google_oauth2]) }
+
+  before do
+    visit log_out_path
+    visit root_path
+    click_button 'Googleでログイン'
+    visit root_path
+  end
+
+  it '既にユーザーのツリーが1件以上あるときは、ツリー一覧上部の「新規作成」ボタンからツリーを新規作成でき、ツリー編集画面に遷移する' do
+    create(:tree, name: 'ツリー1', user_id: user.id)
+    visit root_path
+    expect(page).to have_button('新規作成')
+    expect(page).not_to have_button('ツリーを作成する')
+    click_button '新規作成'
+    expect(page).to have_current_path(edit_tree_path(user.trees.last))
+  end
+
+  it 'ユーザーのツリーが0件のときは、画面内の「ツリーを作成する」ボタンから新規作成でき、ツリー編集画面に遷移する' do
+    expect(page).not_to have_button('新規作成')
+    expect(page).to have_button('ツリーを作成する')
+    click_button 'ツリーを作成する'
+    expect(page).to have_current_path(edit_tree_path(user.trees.last))
+  end
+
+  it '作成されたツリーの名前は、「新しいツリー」になっている' do
+    click_button 'ツリーを作成する'
+    expect(page).to have_current_path(edit_tree_path(user.trees.last))
+    expect(find('h1', text: '新しいツリー')).to be_present
+  end
+
+  it '作成されたツリーは、デフォルトのツリー構造を持っている' do
+    click_button 'ツリーを作成する'
+    expect_tree_node(
+      name: '親の要素',
+      display_value: '100万円',
+      is_value_locked: false,
+      is_leaf: false,
+      operation: nil,
+      has_inconsistent_value: false
+    )
+    expect_tree_node(
+      name: '子の要素1',
+      display_value: '1000万円',
+      is_value_locked: false,
+      is_leaf: true,
+      operation: 'multiply',
+      has_inconsistent_value: false
+    )
+    expect_tree_node(
+      name: '子の要素2',
+      display_value: '10%',
+      is_value_locked: false,
+      is_leaf: true,
+      operation: nil,
+      has_inconsistent_value: false
+    )
+  end
+
+  it 'ツリー一覧画面に戻ると、作成されたツリーが表示されている' do
+    click_button 'ツリーを作成する'
+    expect(find('h1', text: '新しいツリー')).to be_present
+    find('a', text: 'ホーム').click
+    expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: '新しいツリー')
+  end
+
+  it '新規作成したツリーの名前を変更して保存できる' do
+    click_button 'ツリーを作成する'
+    find('.edit-tree-name-button').click
+    find('input[name="tree-name-input"]').set('変更後のツリー名')
+    find('.edit-tree-name-ok').click
+    expect(find('h1', text: '変更後のツリー名')).to be_present
+    find('a', text: 'ホーム').click
+    expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: '変更後のツリー名')
+  end
+
+  it '新規作成したツリーのノードを編集して保存できる' do
+    click_button 'ツリーを作成する'
+    find('g > text', text: '子の要素1').ancestor('g.custom-node').click
+    find_by_id('node-detail-1').find('input[name="name"]').set('子の要素1編集後')
+    find('#updateButton label', text: '更新').click
+    find('.modal-action label', text: '更新する').click
+    expect_tree_node(
+      name: '親の要素',
+      display_value: '100万円',
+      is_value_locked: false,
+      is_leaf: false,
+      operation: nil,
+      has_inconsistent_value: false
+    )
+    expect_tree_node(
+      name: '子の要素1編集後',
+      display_value: '1000万円',
+      is_value_locked: false,
+      is_leaf: true,
+      operation: 'multiply',
+      has_inconsistent_value: false
+    )
+    expect_tree_node(
+      name: '子の要素2',
+      display_value: '10%',
+      is_value_locked: false,
+      is_leaf: true,
+      operation: nil,
+      has_inconsistent_value: false
+    )
+  end
+end


### PR DESCRIPTION
close #23 

## Issue

- https://github.com/peno022/kpi-tree-generator/issues/23

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリー一覧画面の「新規作成」ボタン（一覧に表示する既存のツリーが存在するときに表示するボタン）または「ツリーを作成する」ボタン（ツリーがまだ存在しないときに表示するボタン）をクリックすると、デフォルトのデータでツリーを作成し、ツリー編集画面に遷移するようにした。
- 画面上でヘッダーを表示している部分とその下の部分に境界線を表示したかったので、共通のheaderのスタイルを修正している。それに伴って、welcome画面も境界線のスタイルのみ修正が入っている。

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がることを確認する
4. ログインし、ホーム画面（＝ツリー一覧）にアクセスする（http://localhost:3001/）
5. 新規作成ボタンをクリックする
6. 「新しいツリー」という名前でツリーが作成され、ツリー編集画面に遷移することを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

新規作成ボタン・機能がまだ無い状態。

![スクリーンショット 2023-09-12 18 59 53](https://github.com/peno022/kpi-tree-generator/assets/40317050/1837c551-ccf2-4005-95b9-6a6797030ada)

### 変更後

ツリー一覧があるときは、表の上部に新規作成ボタンを表示：

![スクリーンショット 2023-09-12 18 58 20](https://github.com/peno022/kpi-tree-generator/assets/40317050/7bbeeb37-209a-436e-b426-c0c749e2b594)

ツリーがまだ1件もないときは、タイトル下部にツリーを作成するボタンを表示：

![スクリーンショット 2023-09-12 18 58 36](https://github.com/peno022/kpi-tree-generator/assets/40317050/3079bf75-6c7c-45da-9ca2-52cf66dee16d)

「新規作成」ボタンまたは「ツリーを作成する」ボタンをクリックすると、デフォルトの名前と要素・階層を持つツリーが作成され、そのツリーの編集画面に遷移する：

![スクリーンショット 2023-09-12 18 58 55](https://github.com/peno022/kpi-tree-generator/assets/40317050/a33e89b7-ea29-4da9-a584-02ecbc907d28)