### PR TITLE
ツリー削除機能を実装

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 class TreesController < ApplicationController
+  before_action :set_tree, only: %i[edit destroy]
+
   def edit
-    tree = Tree.find(params[:id])
-    if tree.user_id == current_user.id
-      @tree = tree
-    else
-      render file: Rails.public_path.join('404.html'), status: :not_found, layout: false, content_type: 'text/html'
-    end
+    @tree
   end
 
   def create_and_edit
@@ -23,5 +20,26 @@ class TreesController < ApplicationController
       flash[:alert] = I18n.t('custom_errors.messages.tree_create_failed')
       redirect_to root_path
     end
+  end
+
+  def destroy
+    target_tree_name = @tree.name if @tree
+    @tree.destroy!
+    flash[:notice] = I18n.t('messages.tree_destroyed', target_tree_name:)
+    redirect_to root_path
+  rescue ActiveRecord::RecordNotDestroyed
+    handle_destroy_failure
+  end
+
+  private
+
+  def set_tree
+    @tree = Tree.find_by(id: params[:id], user_id: current_user.id)
+    render file: Rails.root.join('public/404.html').to_s, status: :not_found if @tree.nil?
+  end
+
+  def handle_destroy_failure
+    flash[:alert] = I18n.t('custom_errors.messages.tree_destroy_failed', target_tree_name:)
+    redirect_to root_path
   end
 end

--- a/app/views/shared/_flash.html.slim
+++ b/app/views/shared/_flash.html.slim
@@ -1,3 +1,6 @@
 - if flash[:alert]
   .bg-error.px-4.py-3.text-error-content.text-center
     = flash[:alert]
+- if flash[:notice]
+  .bg-success.px-4.py-3.text-success-content.text-center
+    = flash[:notice]

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -19,12 +19,24 @@
             tr
               td.td-tree-name = link_to tree.name, edit_tree_path(tree)
               td.td-tree-updated-at = tree.updated_at
-              td.td-tree-action
-                button.btn.btn-sm.mr-3
+              td.td-tree-action.flex
+                button.btn.btn-sm.mr-1
                   = link_to edit_tree_path(tree) do
                     | 編集
-                button.btn.btn-sm.btn-ghost.mr-3
+                label.btn.btn-sm.btn-ghost[for="tree_delete_confirm_#{tree.id}"]
                   | 削除
+                input.modal-toggle[type="checkbox" id="tree_delete_confirm_#{tree.id}"]
+                .modal.cursor-pointer
+                  .modal-box
+                    p.py-4
+                      | #{tree.name}を削除してよろしいですか？
+                    .modal-action
+                      label.btn.btn-ghost[for="tree_delete_confirm_#{tree.id}"]
+                        = button_to '削除する', \
+                          tree, \
+                          method: :delete
+                      label.btn[for="tree_delete_confirm_#{tree.id}"]
+                        | キャンセル
 
       = paginate @trees
   - else

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false # デフォルトのtrueから変更
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,3 +42,6 @@ en:
   custom_errors:
     messages:
       tree_create_failed: "The tree failed to create. Please reload the screen and try again."
+      tree_destroy_failed: "Failed to destroy the tree."
+  messages:
+    tree_destroyed: "Deleted the tree %{target_tree_name}."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,3 +215,6 @@ ja:
   custom_errors:
     messages:
       tree_create_failed: "ツリーの作成に失敗しました。画面を再読み込みしてもう一度お試しください。"
+      tree_destroy_failed: "ツリーの削除に失敗しました。画面を再読み込みしてもう一度お試しください。"
+  messages:
+    tree_destroyed: "%{target_tree_name}を削除しました。"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@tailwindcss/typography": "^0.5.9",
     "autoprefixer": "^10.4.13",
-    "daisyui": "^3.6.5",
+    "daisyui": "^3.7.7",
     "esbuild": "^0.16.15",
     "html2canvas": "^1.4.1",
     "list-to-tree": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,7 +2895,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.50.0
     "@typescript-eslint/parser": ^5.50.0
     autoprefixer: ^10.4.13
-    daisyui: ^3.6.5
+    daisyui: ^3.7.7
     esbuild: ^0.16.15
     eslint: ^8.44.0
     eslint-config-prettier: ^8.6.0
@@ -3830,16 +3830,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"daisyui@npm:^3.6.5":
-  version: 3.7.5
-  resolution: "daisyui@npm:3.7.5"
+"daisyui@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "daisyui@npm:3.7.7"
   dependencies:
     colord: ^2.9
     css-selector-tokenizer: ^0.8
     postcss: ^8
     postcss-js: ^4
     tailwindcss: ^3
-  checksum: 5bc5a8bcb9175d080f18162c64def552abfc6add8df5093721901a4faea6d3972311ecfa86a86239d3a209f2214b3b69ace3a1002b590704a014b4c4440a2bde
+  checksum: 85b868e306b04445ac91d902776a74ccf7e57f804a93d43ec785598040e152ce4b2dda883a38cd51d7b9b58779b515639cf5a858731c8314c43063f00040b8e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/121

close #121 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリー一覧画面の「削除」ボタンから、ツリーを削除できるようにした
- daisyuiのバージョンを3.6.5→3.7.7に上げた
- ツリー削除機能のシステムテストを追加した
- システムテストでエラーページが表示されることを確認したく、test環境の`config.consider_all_requests_local`を`false`に変更した

## 動作確認方法

1. VSCode Remote Containerで開発環境を起動
2. bin/devを実行してから、http://localhost:3001 にアクセスし、アプリケーションが問題なく立ち上がることを確認
3. 任意の内容でツリーを作成
4. ツリー一覧の削除ボタンから、ツリーを削除できることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

ツリー一覧画面の削除ボタンの見た目は変わっていないため割愛。
削除ボタンをクリックしても何も起きない状態だった。

### 変更後

![スクリーンショット 2023-09-21 22 15 57](https://github.com/peno022/kpi-tree-generator/assets/40317050/d27217d9-b0b0-445c-8f58-03d01c61a809)

![スクリーンショット 2023-09-21 22 16 06](https://github.com/peno022/kpi-tree-generator/assets/40317050/84d5ed22-c0cc-43a0-abab-9a3762001aae)

![スクリーンショット 2023-09-21 22 16 21](https://github.com/peno022/kpi-tree-generator/assets/40317050/c6496892-edeb-4876-8a47-5d2b3824aa8e)