### PR TITLE
Deploy flyio

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Fly Deploy
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   deploy:
     name: Deploy app

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,15 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,22 @@
+# fly.toml app configuration file generated for kpi-tree on 2023-09-21T06:08:56Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "kpi-tree"
+primary_region = "sjc"
+console_command = "/rails/bin/rails console"
+
+[build]
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[statics]]
+  guest_path = "/rails/public"
+  url_prefix = "/"


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/227

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- `fly launch`を実行して、fly.ioの設定ファイルを追加した
  - 東京リージョンではリソースが足りないエラーが繰り返され、デプロイすることができなかったので、USのSan Joseリージョンに設定している
- mainブランチへのpushをトリガーに、fly.ioへのデプロイを実行するGitHub Actionsワークフローを追加
- また、[How to do Custom Domains with Fly · The Fly Blog](https://fly.io/blog/how-to-custom-domains-with-fly/) のドキュメントの手順に沿って、Route53でDNSレコードを再登録（Cloud RunのIPを登録していたものは削除）

## 動作確認方法

- https://kpi-tree.fly.dev/ でサービスが起動しているのを確認する
- https://kpi-tree.com でサービスが起動しているのを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

割愛

### 変更後

https://kpi-tree.fly.dev/ にアクセス：

![スクリーンショット 2023-09-21 22 56 21](https://github.com/peno022/kpi-tree-generator/assets/40317050/1d53f918-350d-4395-8d78-c82ef71302ec)


https://kpi-tree.com にアクセス：

![スクリーンショット 2023-09-21 23 15 48](https://github.com/peno022/kpi-tree-generator/assets/40317050/2dbf5868-615f-45f8-807f-9856fb41c2a2)