### PR TITLE
ツリー一覧の最終更新を、ツリーとその中のノード・レイヤーを含めた最新の最終更新時刻に修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
 
   def index
     if current_user
-      @trees = current_user.trees.order(updated_at: :desc).page(params[:page]).per(10)
+      @trees = current_user.trees.order_by_latest_updated_at.page(params[:page]).per(10)
       render template: 'trees/index'
     else
       render template: 'welcome/index'

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -18,7 +18,7 @@
           - @trees.each do |tree|
             tr
               td.td-tree-name = link_to tree.name, edit_tree_path(tree)
-              td.td-tree-updated-at = tree.updated_at
+              td.td-tree-updated-at = tree.latest_updated_at.strftime('%Y-%m-%d %H:%M:%S')
               td.td-tree-action.flex
                 button.btn.btn-sm.mr-1
                   = link_to edit_tree_path(tree) do

--- a/spec/models/tree_spec.rb
+++ b/spec/models/tree_spec.rb
@@ -340,6 +340,43 @@ RSpec.describe Tree do
       end
     end
   end
+
+  describe('latest_updated_atは、そのツリーに含まれるノードまたはレイヤーまたはそのツリー自身の中で、最も新しいupdated_atの値を返す') do
+    let!(:user) { create(:user) }
+    let!(:tree) { create(:tree, user:, updated_at: 4.days.ago) }
+    let!(:parent) { create(:node, tree:, updated_at: 5.days.ago) }
+
+    it 'あるノードのupdated_atが一番新しいとき、そのノードのupdated_atを返すこと' do
+      child1 = create(:node, tree:, updated_at: 1.day.ago, parent:)
+      create(:node, tree:, updated_at: 2.days.ago, parent:)
+      create(:layer, tree:, parent_node: parent, updated_at: 3.days.ago)
+      expect(tree.latest_updated_at).to eq(child1.updated_at)
+    end
+
+    it 'あるレイヤーのupdated_atが一番新しいとき、そのレイヤーのupdated_atを返すこと' do
+      create(:node, tree:, updated_at: 2.days.ago, parent:)
+      create(:node, tree:, updated_at: 3.days.ago, parent:)
+      layer = create(:layer, tree:, parent_node: parent, updated_at: 1.day.ago)
+      expect(tree.latest_updated_at).to eq(layer.updated_at)
+    end
+
+    it 'ツリー自身のupdated_atが一番新しいとき、ツリー自身のupdated_atを返すこと' do
+      create(:node, tree:, updated_at: 6.days.ago, parent:)
+      create(:node, tree:, updated_at: 7.days.ago, parent:)
+      create(:layer, tree:, parent_node: parent, updated_at: 8.days.ago)
+      expect(tree.latest_updated_at).to eq(tree.updated_at)
+    end
+  end
+
+  describe 'scope :ordered_by_latest_update は、latest_updated_atの降順でツリーを取得する' do
+    let!(:tree1) { create(:tree, updated_at: 2.days.ago) }
+    let!(:tree2) { create(:tree, updated_at: 3.days.ago) }
+
+    it 'latest_updated_atの降順でツリーを取得すること' do
+      create(:node, tree: tree2, updated_at: 1.day.ago)
+      expect(described_class.order_by_latest_updated_at).to eq([tree2, tree1])
+    end
+  end
 end
 
 def expect_node(node:, value:, unit:, value_format:, is_value_locked:)

--- a/spec/models/tree_spec.rb
+++ b/spec/models/tree_spec.rb
@@ -369,12 +369,12 @@ RSpec.describe Tree do
   end
 
   describe 'scope :ordered_by_latest_update は、latest_updated_atの降順でツリーを取得する' do
-    let!(:tree1) { create(:tree, updated_at: 2.days.ago) }
-    let!(:tree2) { create(:tree, updated_at: 3.days.ago) }
-
     it 'latest_updated_atの降順でツリーを取得すること' do
+      user = create(:user)
+      tree1 = create(:tree, updated_at: 2.days.ago, user:)
+      tree2 = create(:tree, updated_at: 3.days.ago, user:)
       create(:node, tree: tree2, updated_at: 1.day.ago)
-      expect(described_class.order_by_latest_updated_at).to eq([tree2, tree1])
+      expect(user.trees.order_by_latest_updated_at).to eq([tree2, tree1])
     end
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/214

close #214 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリー一覧画面の最終更新時刻の値は、ツリーとその中のノード・レイヤーを含めてツリーの更新を最後に行った時刻としたかったが、ツリーオブジェクト自体の更新（＝ツリー名の変更）をしないと更新されない値になっていたので修正した。
- ツリーオブジェクトのupdated_atを参照する形から、ツリー・ノード・レイヤーupdated_atの中で一番新しい値を参照するように変更。
- あわせて、表示する時刻のフォーマットを「'%Y-%m-%d %H:%M:%S %z'」から「'%Y-%m-%d %H:%M:%S」に変更した。

## 動作確認方法

1. ツリー一覧画面で、ツリーが最終更新時刻の降順に並んでいることを確認する
1. 最新でないツリーをクリックして編集画面にいき、任意のノードまたはレイヤーの情報を編集・更新する
1. ツリー一覧画面に戻り、編集したツリーの最終更新時刻が更新され、一覧の一番上にきていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

ツリーの最終更新時刻の降順で一覧を表示

![スクリーンショット 2023-09-26 10 44 21](https://github.com/peno022/kpi-tree-generator/assets/40317050/d7d18264-542c-4979-a6ba-5cf0ecd44386)

### 変更後

ツリーと、そのツリー内のノード・レイヤー含めた最終更新時刻の降順で一覧を表示

![スクリーンショット 2023-09-26 10 44 10](https://github.com/peno022/kpi-tree-generator/assets/40317050/eb99da8c-fa7e-4e35-b572-10efc3570ac0)