### PR TITLE
デザイン崩れの修正（ツリー一覧画面・編集画面）

### DIFF
--- a/app/javascript/components/trees/tree/CustomNode.tsx
+++ b/app/javascript/components/trees/tree/CustomNode.tsx
@@ -26,6 +26,31 @@ const CustomNode = ({
       createNewChildLayerAndNodes(nodeDatum.attributes.id);
     }
   };
+
+  // nodeDatum.nameを8文字ごとに分割
+  const splitName = nodeDatum.name.match(/.{1,8}/g) || [];
+
+  const displayValueFormat =
+    nodeDatum.attributes?.valueFormat === "なし" || null || undefined
+      ? ""
+      : (nodeDatum.attributes?.valueFormat || "").toString();
+
+  const displayValue =
+    (nodeDatum.attributes?.value.toString() || "") +
+    displayValueFormat +
+    (nodeDatum.attributes?.unit || "");
+
+  const splitDisplayValue =
+    displayValue.length > 13
+      ? [
+          (nodeDatum.attributes?.value.toString() || "") + displayValueFormat,
+          nodeDatum.attributes?.unit || "",
+        ]
+      : [displayValue];
+
+  const displayNameOriginY = splitName.length > 1 ? 30 : 40;
+  const displayValueOriginY = 75;
+
   return (
     <g id={`custom-node-${nodeDatum.attributes?.id.toString()}`}>
       <g>
@@ -47,68 +72,68 @@ const CustomNode = ({
           className="custom-node"
         >
           <rect
-            x="-75"
+            x="-100"
             rx="5"
             ry="5"
             style={
               nodeDatum.attributes?.isSelected
                 ? {
-                    width: "150",
-                    height: "85",
+                    width: "200",
+                    height: "100",
                     fill: "moccasin",
                     stroke: "dimgray",
                     strokeWidth: "1",
                   }
                 : {
-                    width: "150",
-                    height: "85",
+                    width: "200",
+                    height: "100",
                     fill: "ghostwhite",
                     stroke: "dimgray",
                     strokeWidth: "1",
                   }
             }
           />
-          <text
-            x="-60"
-            y="38"
-            style={{
-              fill: "#333",
-              strokeWidth: "0",
-              fontWeight: "bold",
-              fontSize: "1.2em",
-              maxWidth: "280",
-            }}
-          >
-            {nodeDatum.name}
-          </text>
+          {splitName.map((str, index) => (
+            <text
+              key={index}
+              x="-90"
+              y={displayNameOriginY + index * 20}
+              style={{
+                fill: "#333C4D",
+                strokeWidth: "0",
+                fontWeight: "bold",
+                fontSize: "1.2em",
+              }}
+            >
+              {str}
+            </text>
+          ))}
           {nodeDatum.attributes?.isValueLocked && (
             <FontAwesomeIcon
               icon={faLock}
               width={20}
               height={20}
-              x={45}
+              x={70}
               y={10}
               style={{
                 color: "dimgray",
               }}
             />
           )}
-          <text
-            x="-60"
-            y="65"
-            style={{
-              fill: "#333",
-              strokeWidth: "0",
-              fontSize: "1em",
-              maxWidth: "280",
-            }}
-          >
-            {nodeDatum.attributes?.value}
-            {nodeDatum.attributes?.valueFormat === "なし"
-              ? ""
-              : nodeDatum.attributes?.valueFormat}
-            {nodeDatum.attributes?.unit}
-          </text>
+          {splitDisplayValue.map((str, index) => (
+            <text
+              key={index}
+              x="-90"
+              y={displayValueOriginY + index * 20}
+              style={{
+                fill: "#333C4D",
+                strokeWidth: "0",
+                fontSize: "1.1em",
+              }}
+            >
+              {str}
+            </text>
+          ))}
         </g>
       </g>
 
@@ -131,7 +156,7 @@ const CustomNode = ({
           x="130"
           y="42"
           style={{
-            fill: "#333",
+            fill: "#333C4D",
             strokeWidth: "0",
             fontWeight: "bold",
             fontSize: "1.5em",

--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -90,13 +90,20 @@ export const TreeName = () => {
         </>
       ) : (
         <>
-          <h1 className="text-xl font-bold mr-4">{treeNameEditing}</h1>
+            <h1 className="text-xl font-bold md:hidden">
+              {treeNameEditing.length > 9
+                ? treeNameEditing.slice(0, 9) + "…"
+                : treeNameEditing}
+            </h1>
+            <h1 className="text-xl font-bold hidden md:block">
+              {treeNameEditing}
+            </h1>
           <button
             className="btn btn-ghost edit-tree-name-button"
             aria-label="Edit tree name"
             onClick={handleEditButtonClick}
           >
-            <i className="fa fa-lg fa-pencil mx-1" aria-hidden="true"></i>
+            <i className="fa fa-lg fa-pencil" aria-hidden="true"></i>
           </button>
         </>
       )}

--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -90,14 +90,14 @@ export const TreeName = () => {
         </>
       ) : (
         <>
-            <h1 className="text-xl font-bold md:hidden">
-              {treeNameEditing.length > 9
-                ? treeNameEditing.slice(0, 9) + "…"
-                : treeNameEditing}
-            </h1>
-            <h1 className="text-xl font-bold hidden md:block">
-              {treeNameEditing}
-            </h1>
+          <h1 className="text-xl font-bold md:hidden">
+            {treeNameEditing.length > 9
+              ? treeNameEditing.slice(0, 9) + "…"
+              : treeNameEditing}
+          </h1>
+          <h1 className="text-xl font-bold hidden md:block">
+            {treeNameEditing}
+          </h1>
           <button
             className="btn btn-ghost edit-tree-name-button"
             aria-label="Edit tree name"

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -138,7 +138,6 @@ const EditTreePage = () => {
               onUpdateStatusChange={(status: boolean) => setIsUpdating(status)}
             />
           </ErrorBoundary>
-          ;
         </div>
         <div
           className="flex-1 border-l-2 border-base-300 mr-1"

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -117,15 +117,17 @@ const EditTreePage = () => {
     setSelectedNodeIds(selectedNodeIds);
   };
 
+  const isLargeScreen = window.innerWidth >= 1024;
+
   return (
     <>
-      <div className="flex w-full">
+      <div className="flex flex-col lg:flex-row w-full">
         <div>{isUpdating && <Loading></Loading>}</div>
         <div
-          className="flex-1 ml-1"
+          className="flex-1 ml-1 h-1/2 lg:h-auto"
           id="treeWrapper"
           style={{
-            flexGrow: 2,
+            flexGrow: isLargeScreen ? 2 : 1,
             flexBasis: 0,
           }}
         >
@@ -140,7 +142,7 @@ const EditTreePage = () => {
           </ErrorBoundary>
         </div>
         <div
-          className="flex-1 border-l-2 border-base-300 mr-1"
+          className="flex-1 border-t-2 lg:border-l-2 lg:border-t-0 border-base-300 mr-1 h-1/2 lg:h-auto"
           id="toolWrapper"
           style={{
             flexGrow: 1,
@@ -164,7 +166,9 @@ const EditTreePage = () => {
 function fallbackRender({ error }: FallbackProps) {
   return (
     <div role="alert">
-      <p>エラーが発生しています。画面を再読み込みしてもう一度お試しください。</p>
+      <p>
+        エラーが発生しています。画面を再読み込みしてもう一度お試しください。
+      </p>
       <pre style={{ color: "red" }}>{error.message}</pre>
     </div>
   );

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -164,7 +164,7 @@ const EditTreePage = () => {
 function fallbackRender({ error }: FallbackProps) {
   return (
     <div role="alert">
-      <p>Something went wrong:</p>
+      <p>エラーが発生しています。画面を再読み込みしてもう一度お試しください。</p>
       <pre style={{ color: "red" }}>{error.message}</pre>
     </div>
   );

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -5,12 +5,15 @@ nav.bg-base-100.border-b-2.border-base-300.fixed.top-0.left-0.right-0.z-10.flex.
       = image_tag 'ktg-logo-text-compressed.png', alt: 'KPI TREE MAKER logo text', width: 250, class: 'hidden md:block ktg-logo-text'
       = image_tag 'ktg-logo-text-compressed.png', alt: 'KPI TREE MAKER logo text', width: 150, class: 'md:hidden ktg-logo-text'
   .account
-    ul.menu.menu-horizontal.px-1
+    ul.menu.menu-horizontal.px-2.md:px-6
       - if current_user
-        label.btn.btn-ghost.btn-circle.avatar tabindex="0"
-          .w-10.rounded-full
-            = image_tag(current_user.image || 'default-icon.png', alt: 'icon')
-        = link_to 'ログアウト', log_out_path, class: 'btn btn-ghost'
+        .dropdown.dropdown-end
+          label.btn.btn-ghost.btn-circle.avatar tabindex="0"
+            .w-10.rounded-full
+              = image_tag(current_user.image || 'default-icon.png', alt: 'icon')
+          ul.dropdown-content.menu.p-2.shadow.bg-base-100.rounded-box.w-52[tabindex="0"]
+            li data-action="save"
+              = link_to 'ログアウト', log_out_path
       - else
         li
           = button_to 'ログイン', \

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,9 +1,9 @@
 .flex.flex-col.min-h-screen
-  nav.navbar.bg-base-100.flex.items-center.border-b-2.border-base-300
+  nav.bg-base-100.flex.justify-between.items-center.border-b-2.border-base-300
     = link_to root_path, class: 'btn btn-ghost' do
       p.mx-1
         i.fa.fa-lg.fa-angle-left[aria-hidden="true"]
-        p.text-lg
+        p.text-lg.hidden.md:block
           | ホーム
     .dropdown.dropdown-bottom
       ul.menu.dropdown-content.p-2.shadow.bg-base-100.rounded-box.w-52.mt-4[tabindex="0"]
@@ -12,19 +12,33 @@
             | 保存
     .flex-grow.flex.justify-center
       #tree-name data-tree-name=@tree.name data-tree-id=@tree.id
-    a.btn.btn-outline.mx-1 data-action="download-image"
-      | 画像ダウンロード
-    - if current_user
-      - if current_user.image
-        label.btn.btn-ghost.btn-circle.avatar tabindex="0"
-          .w-10.rounded-full
-            = image_tag current_user.image, alt: 'アイコン'
-      = link_to 'ログアウト', log_out_path, class: 'btn btn-ghost'
-    - else
-      li
-        = button_to 'ログイン', \
-        '/auth/google_oauth2', \
-        method: :post, \
-        data: { turbo: false }, \
-        class: 'btn btn-ghost'
+    .md:hidden
+      .dropdown.dropdown-end
+        label.btn.btn-ghost.btn-sm.m-1[tabindex="0"]
+          i.fa-solid.fa-bars
+        ul.dropdown-content.menu.p-2.shadow.bg-base-100.rounded-box.w-52[tabindex="0"]
+          li
+            a data-action="download-image"
+              | 画像ダウンロード
+          li data-action="save"
+            = link_to 'ログアウト', log_out_path
+    .hidden.md:block
+      ul.menu.menu-horizontal.px-2.md:px-6
+        a.btn.btn-outline.mx-4 data-action="download-image"
+          | 画像ダウンロード
+        - if current_user
+            .dropdown.dropdown-end
+              label.btn.btn-ghost.btn-circle.avatar tabindex="0"
+                .w-10.rounded-full
+                  = image_tag(current_user.image || 'default-icon.png', alt: 'icon')
+              ul.dropdown-content.menu.p-2.shadow.bg-base-100.rounded-box.w-52[tabindex="0"]
+                li data-action="save"
+                  = link_to 'ログアウト', log_out_path
+        - else
+          li
+            = button_to 'ログイン', \
+            '/auth/google_oauth2', \
+            method: :post, \
+            data: { turbo: false }, \
+            class: 'btn btn-ghost'
   .flex.grow#tree.w-full.mx-auto data-tree-id=@tree.id

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -1,8 +1,8 @@
 = render 'shared/header'
 .bg-neutral-content.min-h-screen.pt-20
-  .mx-16.my-8
-    .flex.items-center
-      h1.text-xl.font-bold
+  .mx-auto.max-w-7xl
+    .flex.items-center.mx-6.mt-3
+      h1.text-2xl.font-bold
         |ツリー一覧
       - if @trees.any?
         = button_to '新規作成', create_and_edit_trees_path, method: :post,
@@ -21,7 +21,7 @@
                 td.td-tree-name = link_to tree.name, edit_tree_path(tree)
                 td.td-tree-updated-at = tree.latest_updated_at.strftime('%Y-%m-%d %H:%M:%S')
                 td.td-tree-action.flex
-                  button.btn.btn-sm.mr-1
+                  button.btn.btn-sm.space-x-1
                     = link_to edit_tree_path(tree) do
                       | 編集
                   label.btn.btn-sm.btn-ghost[for="tree_delete_confirm_#{tree.id}"]

--- a/spec/javascript/components/trees/TreeName.spec.tsx
+++ b/spec/javascript/components/trees/TreeName.spec.tsx
@@ -101,7 +101,7 @@ describe("TreeName", () => {
         await user.click(okButton);
       });
       expect(mockSendTreeNameUpdateRequest).not.toHaveBeenCalled();
-      expect(screen.getByText("売上ツリー")).toBeInTheDocument();
+      expectVisibleTreeName("売上ツリー");
       expect(
         screen.queryByRole("textbox", {
           name: "tree-name-input",
@@ -129,10 +129,8 @@ describe("TreeName", () => {
 
     it("treeNameと編集ボタンが表示されること", () => {
       render(<TreeName />);
-      const treeName = screen.getByText("売上ツリー");
+      expectVisibleTreeName("売上ツリー");
       const editButton = screen.getByRole("button", { name: "Edit tree name" });
-
-      expect(treeName).toBeInTheDocument();
       expect(editButton).toBeInTheDocument();
     });
 
@@ -162,7 +160,9 @@ describe("TreeName", () => {
       const cancelButton = screen.getByRole("button", { name: "キャンセル" });
       expect(okButton).toBeInTheDocument();
       expect(cancelButton).toBeInTheDocument();
-      expect(editButton).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Edit tree name" })
+      ).not.toBeInTheDocument();
     });
 
     it("キャンセルボタンを押すと、ツリー名の編集がキャンセルされること", async () => {
@@ -183,7 +183,7 @@ describe("TreeName", () => {
       });
       expect(treeNameInput).not.toBeInTheDocument();
       expect(cancelButton).not.toBeInTheDocument();
-      expect(screen.getByText("売上ツリー")).toBeInTheDocument();
+      expectVisibleTreeName("売上ツリー");
       expect(
         screen.getByRole("button", { name: "Edit tree name" })
       ).toBeInTheDocument();
@@ -204,13 +204,7 @@ describe("TreeName", () => {
         "売上ツリー編集後"
       );
       expect(treeNameInput).not.toBeInTheDocument();
-      const allH1Elements = screen.getAllByRole("heading", { level: 1 });
-      const visibleH1ElementsWithText = allH1Elements.filter(
-        (element) =>
-          !element.classList.contains("hidden") &&
-          element.textContent === "編集後のツリー名"
-      );
-      expect(visibleH1ElementsWithText.length).toBe(1);
+      expectVisibleTreeName("編集後のツリー名");
     });
 
     it("ツリー名の編集をして、OKボタンを押すと、OKボタンとキャンセルボタンが表示されないこと", async () => {
@@ -263,3 +257,12 @@ describe("TreeName", () => {
     });
   });
 });
+
+function expectVisibleTreeName(name: string) {
+  const allH1Elements = screen.getAllByRole("heading", { level: 1 });
+  const visibleH1ElementsWithText = allH1Elements.filter(
+    (element) =>
+      !element.classList.contains("hidden") && element.textContent === name
+  );
+  expect(visibleH1ElementsWithText.length).toBe(1);
+}

--- a/spec/javascript/components/trees/TreeName.spec.tsx
+++ b/spec/javascript/components/trees/TreeName.spec.tsx
@@ -204,7 +204,13 @@ describe("TreeName", () => {
         "売上ツリー編集後"
       );
       expect(treeNameInput).not.toBeInTheDocument();
-      expect(screen.getByText("編集後のツリー名")).toBeInTheDocument();
+      const allH1Elements = screen.getAllByRole("heading", { level: 1 });
+      const visibleH1ElementsWithText = allH1Elements.filter(
+        (element) =>
+          !element.classList.contains("hidden") &&
+          element.textContent === "編集後のツリー名"
+      );
+      expect(visibleH1ElementsWithText.length).toBe(1);
     });
 
     it("ツリー名の編集をして、OKボタンを押すと、OKボタンとキャンセルボタンが表示されないこと", async () => {

--- a/spec/system/require_login_spec.rb
+++ b/spec/system/require_login_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'ページごとのログイン要否' do
       it('ウェルカムページにアクセスできること') do
         visit welcome_path
         expect(page).to have_content('KPI ツリーをかんたん作成')
-        expect(page).to have_content('ログアウト')
+        expect(page).to have_css('.avatar')
       end
 
       it('利用規約ページにアクセスできること') do

--- a/spec/system/trees/tree_show_spec.rb
+++ b/spec/system/trees/tree_show_spec.rb
@@ -122,5 +122,21 @@ RSpec.describe 'Tree pages', :js do
       find('g > text', text: '子2').ancestor('g.rd3t-leaf-node').click
       expect(find('.calculation')).to have_css('svg.fa-triangle-exclamation')
     end
+
+    it 'ノード名が9文字以上のときは、改行されて9文字目以降は2行目に表示されること' do
+      tree = create(:tree, user: User.find_by(uid: '1234'))
+      create(:node, name: 'あいうえおかきくけこさしすせそ', value: 1000, unit: '円', tree:)
+      visit edit_tree_path(tree)
+      expect(page).to have_css('g.custom-node > text', text: 'あいうえおかきく')
+      expect(page).to have_css('g.custom-node > text', text: 'けこさしすせそ')
+    end
+
+    it '単位付きのノードの値が13文字を超える時は、単位が2行目に表示されること' do
+      tree = create(:tree, user: User.find_by(uid: '1234'))
+      create(:node, name: 'ルート', value: 123_456_789, value_format: '万', unit: 'あいうえおかきくけこ', tree:)
+      visit edit_tree_path(tree)
+      expect(page).to have_css('g.custom-node > text', text: '123456789万')
+      expect(page).to have_css('g.custom-node > text', text: 'あいうえおかきくけこ')
+    end
   end
 end

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
     it('ノードのプロパティを変更して更新を実行すると、更新後の値でツリーが表示される') do
       # 値を編集
       node_detail1 = find_by_id('node-detail-1')
-      node_detail1.find('input[name="name"]').set('変更後のノード名1')
+      node_detail1.find('input[name="name"]').set('変更後1')
       node_detail1.find('input[name="unit"]').set('人（変更後）')
       node_detail1.find('input[name="value"]').set(2)
       node_detail1.find('select[name="valueFormat"]').select('千')
       node_detail1.find('input[name="isValueLocked"]').set(true)
 
       node_detail2 = find_by_id('node-detail-2')
-      node_detail2.find('input[name="name"]').set('変更後のノード名2')
+      node_detail2.find('input[name="name"]').set('変更後2')
       node_detail2.find('input[name="unit"]').set('円（変更後）')
       node_detail2.find('input[name="value"]').set(4000)
       node_detail2.find('select[name="valueFormat"]').select('なし')
@@ -91,7 +91,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
         is_leaf: false
       )
       expect_tree_node(
-        name: '変更後のノード名1',
+        name: '変更後1',
         display_value: '2千人（変更後）',
         is_value_locked: true,
         operation: 'multiply',
@@ -100,7 +100,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
       )
 
       expect_tree_node(
-        name: '変更後のノード名2',
+        name: '変更後2',
         display_value: '4000円（変更後）',
         is_value_locked: true,
         operation: '',
@@ -526,21 +526,21 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
     it('要素を追加ボタンを押して、追加した要素と既存の要素のプロパティを編集し、更新ボタン→更新するを押すと、ツリーにすべての編集内容が反映される。') do
       click_button '要素を追加'
       node_detail1 = find_by_id('node-detail-1')
-      node_detail1.find('input[name="name"]').set('変更後のノード名1')
+      node_detail1.find('input[name="name"]').set('変更後1')
       node_detail1.find('input[name="unit"]').set('人（変更後）')
       node_detail1.find('input[name="value"]').set(2)
       node_detail1.find('select[name="valueFormat"]').select('千')
       node_detail1.find('input[name="isValueLocked"]').set(true)
 
       node_detail2 = find_by_id('node-detail-2')
-      node_detail2.find('input[name="name"]').set('変更後のノード名2')
+      node_detail2.find('input[name="name"]').set('変更後2')
       node_detail2.find('input[name="unit"]').set('円（変更後）')
       node_detail2.find('input[name="value"]').set(4000)
       node_detail2.find('select[name="valueFormat"]').select('なし')
       node_detail2.find('input[name="isValueLocked"]').set(true)
 
       node_detail3 = find_by_id('node-detail-3')
-      node_detail3.find('input[name="name"]').set('変更後のノード名3')
+      node_detail3.find('input[name="name"]').set('変更後3')
       node_detail3.find('input[name="unit"]').set('円')
       node_detail3.find('input[name="value"]').set(0.1)
       node_detail3.find('select[name="valueFormat"]').select('千')
@@ -550,7 +550,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
       find('.modal-action label', text: '更新する').click
 
       expect_tree_node(
-        name: '変更後のノード名1',
+        name: '変更後1',
         display_value: '2千人（変更後）',
         is_value_locked: true,
         operation: 'multiply',
@@ -558,7 +558,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
         has_inconsistent_value: true
       )
       expect_tree_node(
-        name: '変更後のノード名2',
+        name: '変更後2',
         display_value: '4000円（変更後）',
         is_value_locked: true,
         operation: 'multiply',
@@ -566,7 +566,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
         has_inconsistent_value: true
       )
       expect_tree_node(
-        name: '変更後のノード名3',
+        name: '変更後3',
         display_value: '0.1千円',
         is_value_locked: true,
         operation: '',

--- a/spec/system/trees/trees_index_spec.rb
+++ b/spec/system/trees/trees_index_spec.rb
@@ -138,19 +138,21 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
   describe 'ツリーの削除' do
     context 'ツリーが2件以上あるとき' do
       let!(:tree1) { create(:tree, name: 'ツリー1', user_id: user.id, updated_at: 1.day.ago) }
-      let!(:tree2) { create(:tree, name: 'ツリー2', user_id: user.id, updated_at: 2.days.ago) }
 
       before do
+        create(:tree, name: 'ツリー2', user_id: user.id, updated_at: 2.days.ago)
         visit root_path
       end
 
       it 'ツリーの削除ボタンをクリックすると、削除実行確認モーダルが開くこと' do
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label', text: '削除').click
+        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
+                                                                                              text: '削除').click
         expect(page).to have_content('ツリー1を削除してよろしいですか？')
       end
 
       it '削除実行確認モーダルでキャンセルをクリックすると、モーダルが閉じること' do
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label', text: '削除').click
+        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
+                                                                                              text: '削除').click
         find('label', text: 'キャンセル').click
         expect(page).not_to have_content('ツリー1を削除してよろしいですか？')
       end
@@ -159,7 +161,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
         expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー1')
         expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー2')
         expect(Tree.where(user_id: user.id).count).to eq(2)
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label', text: '削除').click
+        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
+                                                                                              text: '削除').click
         click_button '削除する'
         expect(Tree.where(user_id: user.id).count).to eq(1)
         expect(page).not_to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー1')
@@ -167,7 +170,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       end
 
       it '削除の実行が完了すると、削除完了メッセージが表示されること' do
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label', text: '削除').click
+        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
+                                                                                              text: '削除').click
         click_button '削除する'
         expect(page).to have_content(I18n.t('messages.tree_destroyed', target_tree_name: 'ツリー1'))
       end
@@ -181,7 +185,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
         expect(Tree.where(user_id: user.id).count).to eq(2)
         expect(Node.where(tree_id: tree1.id).count).to eq(3)
         expect(Layer.where(tree_id: tree1.id).count).to eq(1)
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label', text: '削除').click
+        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
+                                                                                              text: '削除').click
         click_button '削除する'
         expect(Tree.where(user_id: user.id).count).to eq(1)
         expect(Node.where(tree_id: tree1.id).count).to eq(0)
@@ -206,7 +211,9 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       it '404エラーページが表示されること' do
         tree = create(:tree, name: '削除されるツリー', user_id: user.id)
         visit root_path
-        find('table > tbody > tr > td.td-tree-name > a', text: '削除されるツリー').ancestor('tr').find('td.td-tree-action > label', text: '削除').click
+        find('table > tbody > tr > td.td-tree-name > a', text: '削除されるツリー').ancestor('tr').find(
+          'td.td-tree-action > label', text: '削除'
+        ).click
         tree.destroy!
         click_button '削除する'
         expect(page).to have_content('404')


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/224

close #224 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

デザイン崩れがある箇所・見づらい箇所を修正した。

### ツリー一覧画面

- テーブルを画面の真ん中に配置する
- テーブルに最大幅を設ける
- 余白を調整
- ヘッダーのログアウトボタンをアイコンクリック時のメニュー内に格納
- 画面変更に応じて既存のテストに影響がある箇所を修正

### ツリー編集画面

- ノード名、数値、単位の文字数が長い時に、改行してノード内に表示が収まるようにする
  - 入力値の文字数・桁数の最大値は今後のissueでバリデーションをかける予定（ #239 ）
  - その前提で最大値まで入力してもはみ出さないように、ノードサイズ・余白も調整
- ヘッダーのログアウトボタンをアイコンクリック時のメニュー内に格納
- SP表示のときにはヘッダーの「ホーム」文言を表示せず、アイコンのみにする
- 余白を調整
- 画面幅が1024px未満のときは、ツールエリアとツリーエリアを上下に1:1で、1024px以上のときは左右に2:1で表示する
- ノードの改行表示のテストケースを追加
- 画面変更に応じて既存のテストに影響がある箇所を修正

## 動作確認方法

- 各画面を表示し、想定どおり（＝添付のキャプチャどおり）に表示できていることを確認する
- 各画面サイズごとにツリー画像が崩れずにダウンロードできていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

下記issueに添付のものを参照：

- https://github.com/peno022/kpi-tree-generator/issues/224

### 変更後

#### ツリー一覧画面

## PC（幅1720ピクセル）

![screencapture-localhost-3001-2023-10-02-18_11_07](https://github.com/peno022/kpi-tree-generator/assets/40317050/8a4605b3-0369-4273-babf-9170914aed1f)

## PC（かなり横長・幅3440ピクセル）

![screencapture-localhost-3001-2023-10-02-18_11_22](https://github.com/peno022/kpi-tree-generator/assets/40317050/ff55eda9-da60-4855-95d5-96aa1fc9041b)

## SP（iPhone12 pro・幅390ピクセル）

![screencapture-localhost-3001-2023-10-02-18_11_48](https://github.com/peno022/kpi-tree-generator/assets/40317050/3815d899-6b37-413d-8ae4-9f66c1ee4b01)

#### ツリー編集画面

## PC（幅1720ピクセル）

![screencapture-localhost-3001-trees-1-edit-2023-10-02-18_13_57](https://github.com/peno022/kpi-tree-generator/assets/40317050/cf5cf27a-1fae-42e8-8c5d-62710e1cd496)

## PC（かなり横長・幅3440ピクセル）

![screencapture-localhost-3001-trees-1-edit-2023-10-02-18_14_13](https://github.com/peno022/kpi-tree-generator/assets/40317050/f7e9a007-8a7f-462b-aec3-e9b8e89f8b42)

## SP（iPhone12 pro・幅390ピクセル）

![screencapture-localhost-3001-trees-1-edit-2023-10-02-18_14_45](https://github.com/peno022/kpi-tree-generator/assets/40317050/814261f7-7054-493c-bc48-c38e67b16e21)


### ノード名・数値・単位の文字数が長い時にノードからはみ出ていたものも修正

![スクリーンショット 2023-10-02 18 13 38](https://github.com/peno022/kpi-tree-generator/assets/40317050/aba0031b-2d21-492d-b69b-c479419ecba8)


