### PR TITLE
Google Tag Manager を導入

### DIFF
--- a/app/views/application/_google_tag_manager_body.html.erb
+++ b/app/views/application/_google_tag_manager_body.html.erb
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TRB5LLSR"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/app/views/application/_google_tag_manager_head.html.erb
+++ b/app/views/application/_google_tag_manager_head.html.erb
@@ -1,0 +1,15 @@
+<!-- Google Tag Manager -->
+<script>
+    dataLayer = [];
+    <% if current_user %>
+      dataLayer.push({
+          'user_id': <%= current_user.id %>
+      });
+    <% end %>
+</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TRB5LLSR');</script>
+<!-- End Google Tag Manager -->

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -5,6 +5,7 @@ html lang='ja'
     = csrf_meta_tags
     = csp_meta_tag
     = display_meta_tags default_meta_tags
+    = render 'google_tag_manager_head'
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
     script src="https://kit.fontawesome.com/48b449efbc.js" crossorigin="anonymous"
@@ -12,5 +13,6 @@ html lang='ja'
     = favicon_link_tag 'touch-icon.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '180x180'
     = favicon_link_tag 'touch-icon.png', rel: 'icon', type: 'image/png', sizes: '192x192'
   body
+    = render 'google_tag_manager_body'
     = render 'shared/flash'
     = yield


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/241

close #241 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- GAでユーザー数・PVを計測できるよう、Google Tag Managerを導入した。
- GTM側でタグを発行し、scriptを貼り付け。
- bootcampも参考にした。
  - bootcampではRails.envがproductionの時のみscriptがrenderされるようになっていたが、今回は開発環境での計測確認も実施したいので、scriptには条件をつけず、GTM側で計測をlocalhostと本番ドメインとで分けた。

## 動作確認方法

- プレビュー画面で、localhostにアクセスした時にはDEV用IDでの計測が、kpi-tree.comにアクセスした時にはPROD用IDでの計測が発火していることを確認。
- GAのリアルタイム計測画面で、自分のアクセスが計測されていることを確認。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛
