### PR TITLE
PC表示で画像ダウンロードボタンが効かなくなっていた問題を修正

### DIFF
--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -63,11 +63,15 @@ const EditTreePage = () => {
   };
 
   useEffect(() => {
-    const button = document.querySelector("[data-action='download-image']");
-    button?.addEventListener("click", downloadImage);
+    const buttons = document.querySelectorAll("[data-action='download-image']");
+    buttons.forEach((button) => {
+      button.addEventListener("click", downloadImage);
+    });
 
     return () => {
-      button?.removeEventListener("click", downloadImage);
+      buttons.forEach((button) => {
+        button.removeEventListener("click", downloadImage);
+      });
     };
   }, []);
 

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -12,7 +12,7 @@ nav.bg-base-100.border-b-2.border-base-300.fixed.top-0.left-0.right-0.z-10.flex.
             .w-10.rounded-full
               = image_tag(current_user.image || 'default-icon.png', alt: 'icon')
           ul.dropdown-content.menu.p-2.shadow.bg-base-100.rounded-box.w-52[tabindex="0"]
-            li data-action="save"
+            li
               = link_to 'ログアウト', log_out_path
       - else
         li

--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -6,11 +6,6 @@
         i.fa.fa-lg.fa-angle-left[aria-hidden="true"]
         p.text-lg.hidden.md:block
           | ホーム
-    .dropdown.dropdown-bottom
-      ul.menu.dropdown-content.p-2.shadow.bg-base-100.rounded-box.w-52.mt-4[tabindex="0"]
-        li
-          a
-            | 保存
     .flex-grow.flex.justify-center
       #tree-name data-tree-name=@tree.name data-tree-id=@tree.id
     .md:hidden
@@ -21,7 +16,7 @@
           li
             a data-action="download-image"
               | 画像ダウンロード
-          li data-action="save"
+          li
             = link_to 'ログアウト', log_out_path
     .hidden.md:block
       ul.menu.menu-horizontal.px-2.md:px-6
@@ -33,7 +28,7 @@
                 .w-10.rounded-full
                   = image_tag(current_user.image || 'default-icon.png', alt: 'icon')
               ul.dropdown-content.menu.p-2.shadow.bg-base-100.rounded-box.w-52[tabindex="0"]
-                li data-action="save"
+                li
                   = link_to 'ログアウト', log_out_path
         - else
           li


### PR DESCRIPTION
## Issue

- なし。今日マージした PR（https://github.com/peno022/kpi-tree-generator/pull/240 ）にバグがあったので急ぎ修正。

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- 幅768px以上の画面の画像ダウンロードボタンが効かなくなっていた。
- ツリー編集画面のレスポンシブ対応をした際に、PC表示用の画像ダウンロードボタンに加えてSP表示用の画像ダウンロードボタンの要素を追加したが、edit.tsxではquerySelectorで1つのボタン要素しか取得していなかったため、PC表示用の画像ダウンロードボタンのクリックイベントをリッスンできていなかったことが原因。
- 複数の画像ダウンロードボタンのイベントをリッスンできるように修正した。

## 動作確認方法

- ツリー編集画面で、ウィンドウサイズを幅768px以上にして画像ダウンロードできることを確認
- 同じく、ウィンドウサイズを幅768px未満にして画像ダウンロードできることを確認

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛