### PR TITLE
ツリー編集画面で入力できる値の文字数に上限値を設定

### DIFF
--- a/app/javascript/hooks/useLayerToolLogic.ts
+++ b/app/javascript/hooks/useLayerToolLogic.ts
@@ -51,6 +51,15 @@ const useLayerToolLogic = (
         layer: newLayerValues,
       });
       return;
+    } else if (numericValue.toString().length > 9) {
+      setFractionValidation(false);
+      setFractionErrorMessage("9桁以内で入力してください");
+      newLayerValues.fraction = 0;
+      setLayerProperty({
+        ...layerProperty,
+        layer: newLayerValues,
+      });
+      return;
     }
     newLayerValues.fraction = numericValue;
     setFractionValidation(true);

--- a/app/javascript/hooks/useNodeDetailLogic.ts
+++ b/app/javascript/hooks/useNodeDetailLogic.ts
@@ -36,6 +36,14 @@ const useNodeDetailLogic = (
         handleFieldValidationErrorsChange([
           { index, fieldName: "name", errorMessage: "必須項目です" },
         ]);
+      } else if (value.toString().length > 15) {
+        handleFieldValidationErrorsChange([
+          {
+            index,
+            fieldName: "name",
+            errorMessage: "15文字以内で入力してください",
+          },
+        ]);
       } else {
         handleFieldValidationErrorsChange([
           { index, fieldName: "name", errorMessage: "" },
@@ -56,6 +64,14 @@ const useNodeDetailLogic = (
             errorMessage: "数値を入力してください",
           },
         ]);
+      } else if (value.toString().length > 9) {
+        handleFieldValidationErrorsChange([
+          {
+            index,
+            fieldName: "value",
+            errorMessage: "9桁以内で入力してください",
+          },
+        ]);
       } else {
         handleFieldValidationErrorsChange([
           { index, fieldName: name, errorMessage: "" },
@@ -65,19 +81,49 @@ const useNodeDetailLogic = (
     }
 
     if (name === "valueFormat") {
-      if (value === "%" && updatedNodeInfo.unit !== "") {
-        handleFieldValidationErrorsChange([
-          {
-            index,
-            fieldName: "unit",
-            errorMessage: "％表示のときは単位を空にしてください",
-          },
-          {
-            index,
-            fieldName: "valueFormat",
-            errorMessage: "％表示のときは単位を空にしてください",
-          },
-        ]);
+      if (updatedNodeInfo.unit !== "") {
+        if (value === "%") {
+          handleFieldValidationErrorsChange([
+            {
+              index,
+              fieldName: "unit",
+              errorMessage: "％表示のときは単位を空にしてください",
+            },
+            {
+              index,
+              fieldName: "valueFormat",
+              errorMessage: "％表示のときは単位を空にしてください",
+            },
+          ]);
+        } else {
+          if (updatedNodeInfo.unit.length > 10) {
+            handleFieldValidationErrorsChange([
+              {
+                index,
+                fieldName: "unit",
+                errorMessage: "10文字以内で入力してください",
+              },
+              {
+                index,
+                fieldName: "valueFormat",
+                errorMessage: "",
+              },
+            ]);
+          } else {
+            handleFieldValidationErrorsChange([
+              {
+                index,
+                fieldName: "unit",
+                errorMessage: "",
+              },
+              {
+                index,
+                fieldName: "valueFormat",
+                errorMessage: "",
+              },
+            ]);
+          }
+        }
       } else {
         handleFieldValidationErrorsChange([
           {
@@ -96,32 +142,57 @@ const useNodeDetailLogic = (
     }
 
     if (name === "unit") {
-      if (value !== "" && updatedNodeInfo.valueFormat === "%") {
-        handleFieldValidationErrorsChange([
-          {
-            index,
-            fieldName: "unit",
-            errorMessage: "％表示のときは単位を空にしてください",
-          },
-          {
-            index,
-            fieldName: "valueFormat",
-            errorMessage: "％表示のときは単位を空にしてください",
-          },
-        ]);
+      if (updatedNodeInfo.valueFormat === "%") {
+        if (value !== "") {
+          handleFieldValidationErrorsChange([
+            {
+              index,
+              fieldName: "unit",
+              errorMessage: "％表示のときは単位を空にしてください",
+            },
+            {
+              index,
+              fieldName: "valueFormat",
+              errorMessage: "％表示のときは単位を空にしてください",
+            },
+          ]);
+        } else {
+          handleFieldValidationErrorsChange([
+            {
+              index,
+              fieldName: "unit",
+              errorMessage: "",
+            },
+            {
+              index,
+              fieldName: "valueFormat",
+              errorMessage: "",
+            },
+          ]);
+        }
       } else {
-        handleFieldValidationErrorsChange([
-          {
-            index,
-            fieldName: "unit",
-            errorMessage: "",
-          },
-          {
-            index,
-            fieldName: "valueFormat",
-            errorMessage: "",
-          },
-        ]);
+        if (value.toString().length > 10) {
+          handleFieldValidationErrorsChange([
+            {
+              index,
+              fieldName: "unit",
+              errorMessage: "10文字以内で入力してください",
+            },
+          ]);
+        } else {
+          handleFieldValidationErrorsChange([
+            {
+              index,
+              fieldName: "unit",
+              errorMessage: "",
+            },
+            {
+              index,
+              fieldName: "valueFormat",
+              errorMessage: "",
+            },
+          ]);
+        }
       }
       return;
     }

--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -36,6 +36,10 @@ export const TreeName = () => {
       setErrorMessage("ツリー名を入力してください");
       return;
     }
+    if (treeNameEditing.length > 50) {
+      setErrorMessage("50文字以内で入力してください");
+      return;
+    }
     if (treeNameEditing === treeName) {
       setIsEditing(false);
       return;

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -5,5 +5,5 @@ class Layer < ApplicationRecord
   belongs_to :parent_node, class_name: 'Node'
   belongs_to :tree
   validates :operation, presence: true
-  validates :fraction, numericality: true
+  validates :fraction, numericality: { less_than_or_equal_to: 999_999_999 }
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -9,9 +9,10 @@ class Node < ApplicationRecord
                         inverse_of: :parent_node
   has_many :children, class_name: 'Node', foreign_key: 'parent_id', dependent: :destroy, inverse_of: :parent
 
-  validates :name, presence: true
-  validates :value, presence: true, numericality: true
-  validates :value_format, presence: true # memo:enumで定義していない値を渡すと、RailsのArgumentErroｒになる
+  validates :name, presence: true, length: { maximum: 15 }
+  validates :value, presence: true, numericality: { less_than_or_equal_to: 999_999_999 }
+  validates :value_format, presence: true
+  validates :unit, length: { maximum: 10 }
   validates :unit, absence: true, if: :percent_formatted?
 
   def percent_formatted?

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -4,7 +4,7 @@ class Tree < ApplicationRecord
   belongs_to :user
   has_many :nodes, dependent: :destroy
   has_many :layers, dependent: :destroy
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
 
   scope :order_by_latest_updated_at, lambda {
     select('trees.*,

--- a/db/migrate/20231003095728_add_validations_to_models.rb
+++ b/db/migrate/20231003095728_add_validations_to_models.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddValidationsToModels < ActiveRecord::Migration[7.0]
+  def up
+    change_table :nodes, bulk: true do |t|
+      t.change :name, :string, limit: 15
+      t.change :unit, :string, limit: 10
+    end
+    change_column :trees, :name, :string, limit: 50
+  end
+
+  def down
+    change_table :nodes, bulk: true do |t|
+      t.change :name, :string, limit: nil
+      t.change :unit, :string, limit: nil
+    end
+    change_column :trees, :name, :string, limit: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_05_105355) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_095728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,10 +26,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_05_105355) do
   end
 
   create_table "nodes", force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 15
     t.float "value"
     t.integer "value_format"
-    t.string "unit"
+    t.string "unit", limit: 10
     t.boolean "is_value_locked", default: false
     t.bigint "tree_id", null: false
     t.bigint "parent_id"
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_05_105355) do
   end
 
   create_table "trees", force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 50
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -56,4 +56,10 @@ RSpec.describe Layer do
     layer.valid?
     expect(layer.errors[:fraction]).to include('is not a number')
   end
+
+  it 'fractionが10桁以上だと無効になる' do
+    layer = described_class.new(fraction: 1_000_000_000)
+    expect(layer).not_to be_valid
+    expect(layer.errors[:fraction]).to include('must be less than or equal to 999999999')
+  end
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe Node do
       node.valid?
       expect(node.errors[:unit]).to be_empty
     end
+
+    it 'nameが16文字以上だと無効になる' do
+      node = described_class.new(name: 'a' * 16)
+      expect(node).not_to be_valid
+      expect(node.errors[:name]).to include('is too long (maximum is 15 characters)')
+    end
+
+    it 'valueが10文字以上だと無効になる' do
+      node = described_class.new(value: 1_000_000_000)
+      expect(node).not_to be_valid
+      expect(node.errors[:value]).to include('must be less than or equal to 999999999')
+    end
+
+    it 'unitが11文字以上だと無効になる' do
+      node = described_class.new(unit: 'a' * 11)
+      expect(node).not_to be_valid
+      expect(node.errors[:unit]).to include('is too long (maximum is 10 characters)')
+    end
   end
 
   describe 'default values' do

--- a/spec/models/tree_spec.rb
+++ b/spec/models/tree_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Tree do
       tree.valid?
       expect(tree.errors[:name]).to include("can't be blank")
     end
+
+    it 'nameが51文字以上だと無効になる' do
+      tree = described_class.new(name: 'a' * 51)
+      expect(tree).not_to be_valid
+      expect(tree.errors[:name]).to include('is too long (maximum is 50 characters)')
+    end
   end
 
   describe('update_tree_with_params') do

--- a/spec/system/tool/tool_validation_spec.rb
+++ b/spec/system/tool/tool_validation_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'ツールエリアのバリデーションチェック', :js, :l
     find('g > text', text: '子1').ancestor('g.rd3t-leaf-node').click
   end
 
-  describe 'ノードの単項目のチェック' do
+  describe 'ノードの単項目バリデーション' do
     it('バリデーションエラーがないときは、エラー文言が表示されず、更新ボタンが押せる') do
       # 初期表示でバリデーションエラーがない状態
       expect(page).not_to have_css('span.text-error')
@@ -115,9 +115,24 @@ RSpec.describe 'ツールエリアのバリデーションチェック', :js, :l
       expect(find_by_id('node-detail-1').find('input[name="value"]')['class']).to include('input-error')
       expect(page).to have_css('label.btn.btn-primary.btn-disabled', text: '更新')
     end
+
+    it('ノード名を16文字以上入力するとエラーが表示される') do
+      find_by_id('node-detail-1').find('input[name="name"]').set('あいうえおかきくけこさしすせそた')
+      expect(page).to have_css('span.text-error', text: '15文字以内で入力してください', count: 1)
+    end
+
+    it('数値を10文字以上入力するとエラーが表示される') do
+      find_by_id('node-detail-1').find('input[name="value"]').set('1234567890')
+      expect(page).to have_css('span.text-error', text: '9桁以内で入力してください', count: 1)
+    end
+
+    it('単位を11文字以上入力するとエラーが表示される') do
+      find_by_id('node-detail-1').find('input[name="unit"]').set('あいうえおかきくけこさ')
+      expect(page).to have_css('span.text-error', text: '10文字以内で入力してください', count: 1)
+    end
   end
 
-  describe '端数の数値形式チェック' do
+  describe '端数のバリデーション' do
     it('端数が空白のときは、エラーは表示されない') do
       find('input[name="fraction"]').set('')
       expect(page).not_to have_css('span.text-error')
@@ -162,6 +177,11 @@ RSpec.describe 'ツールエリアのバリデーションチェック', :js, :l
       expect(page).to have_css('span.text-error', text: '数値を入力してください', count: 1)
       expect(find('input[name="fraction"]')['class']).to include('input-error')
       expect(page).to have_css('label.btn.btn-primary.btn-disabled', text: '更新')
+    end
+
+    it('端数を10文字以上入力するとエラーが表示される') do
+      find('input[name="fraction"]').set('1234567890')
+      expect(page).to have_css('span.text-error', text: '9桁以内で入力してください', count: 1)
     end
   end
 

--- a/spec/system/trees/tree_name_update_spec.rb
+++ b/spec/system/trees/tree_name_update_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe 'ツリー名を変更する', :js, :login_required do
       expect(page).to have_text('ツリー名を入力してください')
     end
 
+    it 'ツリー名を51文字以上入力した状態でOKボタンを押すと、「50文字以内で入力してください」というエラーが表示される' do
+      find('.edit-tree-name-button').click
+      find('input[name="tree-name-input"]').set('a' * 51)
+      find('.edit-tree-name-ok').click
+      expect(page).to have_text('50文字以内で入力してください')
+    end
+
     it 'エラーメッセージが表示された後、キャンセルボタンを押すとエラーが消える' do
       find('.edit-tree-name-button').click
       find('input[name="tree-name-input"]').set('')


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/239

close #239 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ユーザーが編集できる値について、下記のとおりに最大文字数の制約をもうけた。
- 追加した制約を確認するテストを追加した。

|                | 画面（React） | Model                 | DB         | 
| -------------- | ------------- | --------------------- | ---------- | 
| Node.name      | 15文字以内    | 15文字以内            | 15文字以内 | 
| Node.value     | 9文字以内     | 999,999,999以下の数値 | ー         | 
| Node.unit      | 10文字以内    | 10文字以内            | 10文字以内 | 
| Layer.fraction | 9文字以内     | 999,999,999以下の数値 | ー         | 
| Tree.name      | 50文字以内    | 50文字以内            | 50文字以内 | 

## 動作確認方法

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

文字数のバリデーションは全くかかっていない状態だったため、割愛。

### 変更後

#### ノードの名前を16文字入力した時

![スクリーンショット 2023-10-03 19 54 23](https://github.com/peno022/kpi-tree-generator/assets/40317050/c1872c76-cbce-46fb-b493-b24a7b4b2522)

#### ノードの数値を10文字入力した時

![スクリーンショット 2023-10-03 19 54 14](https://github.com/peno022/kpi-tree-generator/assets/40317050/9c2b95b6-6eef-4c5b-a056-e4643977dac8)

#### ノードの単位を11文字入力した時

![スクリーンショット 2023-10-03 19 54 45](https://github.com/peno022/kpi-tree-generator/assets/40317050/34aefbe9-0957-4206-9e4b-9f5f9f0256a5)

#### 端数を10文字入力した時

![スクリーンショット 2023-10-03 19 54 58](https://github.com/peno022/kpi-tree-generator/assets/40317050/a248bac5-eaf5-45d2-81cc-1cc6a810e69e)

#### ツリー名を51文字入力してOKボタンを押した時

![スクリーンショット 2023-10-03 19 53 28](https://github.com/peno022/kpi-tree-generator/assets/40317050/8f00447d-5ba7-4f9b-b6dc-8ddff1e79c26)
