### PR TITLE
ツリー0件のときのデザインを調整、flashの表示位置を修正

### DIFF
--- a/app/views/shared/_flash.html.slim
+++ b/app/views/shared/_flash.html.slim
@@ -1,6 +1,6 @@
 - if flash[:alert]
-  .bg-error.px-4.py-3.text-error-content.text-center
+  .bg-error.px-4.py-3.text-error-content.text-center.pt-20
     = flash[:alert]
 - if flash[:notice]
-  .bg-success.px-4.py-3.text-success-content.text-center
+  .bg-success.px-4.py-3.text-success-content.text-center.pt-20
     = flash[:notice]

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -1,6 +1,6 @@
 - title 'KPIツリー一覧'
 = render 'shared/header'
-.bg-neutral-content.min-h-screen.pt-20
+.bg-neutral-content.min-h-screen.pt-20.text-neutral
   .mx-auto.max-w-7xl
     .flex.items-center.mx-6.mt-3
       h1.text-2xl.font-bold
@@ -42,7 +42,8 @@
 
         = paginate @trees
     - else
-      .text-base.mt-6.mb-4
-        |まだツリーがありません。
-      = button_to 'ツリーを作成する', create_and_edit_trees_path, method: :post,
-        class: 'btn btn-primary my-2'
+      .m-8
+        .text-lg.mb-4
+          | まだツリーがありません。
+        = button_to 'ツリーを作成する', create_and_edit_trees_path, method: :post,
+          class: 'btn btn-primary my-2'


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/249

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

#224 での対応漏れを修正している。

- ツリー0件のときのデザインを調整
  - ツリー一覧画面について、ツリーが1件以上あるときのデザインは修正済みだが、0件の時は修正できていなかった。
  - 左に寄りすぎていたので、余白を修正。
- flashの表示位置を修正
  - ヘッダーを固定表示に修正した際に、flashが隠れるようになってしまったので、余白を追加する形で修正。


## 動作確認方法

- ツリーがない状態でツリー一覧画面を表示し、表示が添付のキャプチャどおりになっていることを確認する
- ツリーを作成→削除し、flashメッセージが表示されることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

#### ツリー0件のときのツリー一覧画面

##### 幅1720px

![screencapture-localhost-3000-2023-10-03-22_31_32](https://github.com/peno022/kpi-tree-generator/assets/40317050/4acb68a3-ee47-491c-aeda-f70d81298605)


##### 幅3440px

![screencapture-localhost-3000-2023-10-03-22_31_58](https://github.com/peno022/kpi-tree-generator/assets/40317050/e7b355cd-ee87-44ed-9b52-507bc91472dc)

##### 幅390px

![screencapture-localhost-3000-2023-10-03-22_32_14](https://github.com/peno022/kpi-tree-generator/assets/40317050/f3db53ce-5292-469f-9889-75bbc88400d7)

#### flashの表示（ヘッダーに隠れて見えない）

![スクリーンショット 2023-10-03 22 33 11](https://github.com/peno022/kpi-tree-generator/assets/40317050/de7e28f8-ebb5-4dab-8c62-0d55cc3bc630)


### 変更後

#### ツリー0件のときのツリー一覧画面

##### 幅1720px

![screencapture-localhost-3000-2023-10-03-22_27_51](https://github.com/peno022/kpi-tree-generator/assets/40317050/122b2d36-71f7-4bf4-8d9f-9ff7c5360840)

##### 幅3440px

![screencapture-localhost-3000-2023-10-03-22_28_01](https://github.com/peno022/kpi-tree-generator/assets/40317050/c3d4e77e-3091-4ce7-86ea-094b59df10a6)


##### 幅390px

![screencapture-localhost-3000-2023-10-03-22_28_17](https://github.com/peno022/kpi-tree-generator/assets/40317050/a22848c7-4842-4369-8a8e-2ae5929a20d6)


#### flashの表示

![スクリーンショット 2023-10-03 22 28 49](https://github.com/peno022/kpi-tree-generator/assets/40317050/e5d661d2-d8a5-4109-8cd0-1b9b0e8867b2)

