### PR TITLE
ツリー名更新時のエラーを画面に表示できていなかったので修正

### DIFF
--- a/app/controllers/api/trees_controller.rb
+++ b/app/controllers/api/trees_controller.rb
@@ -23,11 +23,10 @@ module Api
     end
 
     def update_name
-      Rails.logger.info "Updating tree name to #{params[:name]}"
       if @tree.update(name: params[:name])
         render json: { name: @tree.reload.name }, status: :ok
       else
-        render json: { errors: @tree.errors.full_messages.join(', ') }, status: :unprocessable_entity
+        render json: { errors: @tree.errors.full_messages }, status: :unprocessable_entity
       end
     end
 

--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -50,7 +50,6 @@ export const TreeName = () => {
       setIsEditing(false);
     } else {
       setTreeNameEditing(treeName);
-      setErrorMessage("ツリー名の更新に失敗しました。再度お試しください。");
     }
   };
 

--- a/spec/requests/trees_api_spec.rb
+++ b/spec/requests/trees_api_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe 'TreesApi' do
       tree = create(:tree, user_id: user.id)
       patch "/api/trees/#{tree.id}/update_name.json", params: { name: nil }
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.parsed_body['errors']).to eq("Name can't be blank")
+      expect(response.parsed_body['errors']).to eq(["Name can't be blank"])
     end
 
     it 'ログインユーザーのツリーの名前を更新すること' do


### PR DESCRIPTION
## Issue

別なissue対応中に見つけてすぐに修正したものになるので、issue起票なし。

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- treeのupdate_nameのAPIがエラーメッセージを返す形式と、受け取ったコンポーネント側で想定する形式がずれていたので修正。
  - API側からは配列の状態で返すように修正。コンポーネント側でカンマ区切りで結合して表示する。
  - 受け取ったメッセージコンポーネント側で上書きしてしまっていた箇所を削除。
- 上記修正にあわせて既存のテストを修正。

## 動作確認方法

- update_nameのAPIが返すエラーが画面に表示されること
- テストがパスしていること

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛。
