### PR TITLE
ヘッダーの「ホーム」を「ツリー一覧」にする

### DIFF
--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -5,7 +5,7 @@
       p.mx-1
         i.fa.fa-lg.fa-angle-left[aria-hidden="true"]
         p.text-lg.hidden.md:block
-          | ホーム
+          | ツリー一覧
     .flex-grow.flex.justify-center
       #tree-name data-tree-name=@tree.name data-tree-id=@tree.id
     .md:hidden

--- a/spec/system/trees/tree_create_spec.rb
+++ b/spec/system/trees/tree_create_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'ツリーを新規作成する', :js, :login_required do
   it 'ツリー一覧画面に戻ると、作成されたツリーが表示されている' do
     click_button 'ツリーを作成する'
     expect(page).to have_css('h1', text: '新しいツリー')
-    find('a', text: 'ホーム').click
+    find('a', text: 'ツリー一覧').click
     expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: '新しいツリー')
   end
 
@@ -75,7 +75,7 @@ RSpec.describe 'ツリーを新規作成する', :js, :login_required do
     find('input[name="tree-name-input"]').set('変更後のツリー名')
     find('.edit-tree-name-ok').click
     expect(page).to have_css('h1', text: '変更後のツリー名')
-    find('a', text: 'ホーム').click
+    find('a', text: 'ツリー一覧').click
     expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: '変更後のツリー名')
   end
 


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/265

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

close #265 

## 概要

ツリー編集画面のヘッダーナビゲーションの「ホーム」という文言を、遷移先画面の実体に合わせて「ツリー一覧」に変更した。

## 動作確認方法

ログインして任意のツリーの編集画面に遷移し、ヘッダー左側のナビゲーション文言が「ツリー一覧」になっていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-10-24 23 30 23](https://github.com/peno022/kpi-tree-generator/assets/40317050/93fdc1ca-0491-4511-96c2-32a18588e7ea)
<img height="500" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/a563c74d-7f2a-40eb-ac71-dff78f524883">


### 変更後
![スクリーンショット 2023-10-24 23 29 25](https://github.com/peno022/kpi-tree-generator/assets/40317050/1adf20c1-aa1d-4fb0-ae96-089eebb1890d)
<img height="500" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/ef00aaa7-288f-4024-a052-9e8df0edf01a">