### PR TITLE
トップページフッターの border width を 2px → 1px に変更

### DIFF
--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -72,7 +72,7 @@
           | ご利用には Google アカウントが必要です。
           br
           | サインアップによって、利用規約・プライバシーポリシーに同意したものとみなします。
-  footer.footer.footer-center.p-10.bg-base-100.text-base-content.rounded.border-base-300.border-t-2
+  footer.footer.footer-center.p-10.bg-base-100.text-base-content.rounded.border-base-300.border-t
     .grid.grid-flow-col.gap-4
       = link_to '利用規約', terms_of_use_path, class: 'link link-hover'
       = link_to 'プライバシーポリシー', privacy_policy_path, class: 'link link-hover'


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/270

close #270 
<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

トップページフッターの border width を 2px → 1px に変更した。

## 動作確認方法

ログインしていない状態でトップページにアクセスし、フッターのborder width が 2px → 1px になっていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前
![スクリーンショット 2023-10-25 8 26 50](https://github.com/peno022/kpi-tree-generator/assets/40317050/2434acf0-d65e-4594-84b1-f72f99597a9e)

<img height="500" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/f13ad776-51c3-4f0e-83f0-12b1a8a3f24a">

### 変更後
![スクリーンショット 2023-10-25 8 30 24](https://github.com/peno022/kpi-tree-generator/assets/40317050/96170eee-39e0-4a9c-8ab5-d1e1a4b43d0e)
<img height="500" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/dfed32b9-93f4-452f-9de1-3eee158f0292">