### PR TITLE
ツリー一覧のレイアウトを変更

### DIFF
--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -9,37 +9,34 @@
         = button_to '新規作成', create_and_edit_trees_path, method: :post,
         class: 'btn btn-sm my-2 ml-10'
     - if @trees.any?
-      .overflow-x-auto.m-3
-        table.table.table-lg
-          thead
-            tr
-              th 名前
-              th 最終更新
-              th
-          tbody
-            - @trees.each do |tree|
-              tr
-                td.td-tree-name = link_to tree.name, edit_tree_path(tree)
-                td.td-tree-updated-at = tree.latest_updated_at.strftime('%Y-%m-%d %H:%M:%S')
-                td.td-tree-action.flex
-                  button.btn.btn-sm.space-x-1
-                    = link_to edit_tree_path(tree) do
-                      | 編集
-                  label.btn.btn-sm.btn-ghost[for="tree_delete_confirm_#{tree.id}"]
-                    | 削除
-                  input.modal-toggle[type="checkbox" id="tree_delete_confirm_#{tree.id}"]
-                  .modal.cursor-pointer
-                    .modal-box
-                      p.py-4
-                        | #{tree.name}を削除してよろしいですか？
-                      .modal-action
-                        label.btn.btn-ghost[for="tree_delete_confirm_#{tree.id}"]
-                          = button_to '削除する', \
-                            tree, \
-                            method: :delete
-                        label.btn[for="tree_delete_confirm_#{tree.id}"]
-                          | キャンセル
-
+      .overflow-x-auto.m-3.trees
+        - @trees.each do |tree|
+          .border-b.border-gray-200.p-4.tree
+            .flex.justify-between.items-center
+              .tree-name.p-2.text-lg.w-2/3
+                = link_to tree.name, edit_tree_path(tree)
+              .tree-action.w-1/3.flex.justify-center
+                button.btn.btn-sm.mx-1
+                  = link_to edit_tree_path(tree) do
+                    | 編集
+                label.btn.btn-sm.mr-1.btn-ghost[for="tree_delete_confirm_#{tree.id}"]
+                  | 削除
+                input.modal-toggle[type="checkbox" id="tree_delete_confirm_#{tree.id}"]
+                .modal.cursor-pointer
+                  .modal-box
+                    p.py-4
+                      | #{tree.name}を削除してよろしいですか？
+                    .modal-action
+                      label.btn.btn-ghost[for="tree_delete_confirm_#{tree.id}"]
+                        = button_to '削除する', \
+                          tree, \
+                          method: :delete
+                      label.btn[for="tree_delete_confirm_#{tree.id}"]
+                        | キャンセル
+            .tree-updated-at.text-sm.text-gray-500.px-2
+              | 最終更新:
+              = "  "
+              = tree.latest_updated_at.strftime('%Y年%m月%d日 %H:%M')
         = paginate @trees
     - else
       .m-8

--- a/spec/system/trees/tree_create_spec.rb
+++ b/spec/system/trees/tree_create_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'ツリーを新規作成する', :js, :login_required do
     click_button 'ツリーを作成する'
     expect(page).to have_css('h1', text: '新しいツリー')
     find('a', text: 'ツリー一覧').click
-    expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: '新しいツリー')
+    expect(page).to have_selector('.tree-name', text: '新しいツリー')
   end
 
   it '新規作成したツリーの名前を変更して保存できる' do
@@ -76,7 +76,7 @@ RSpec.describe 'ツリーを新規作成する', :js, :login_required do
     find('.edit-tree-name-ok').click
     expect(page).to have_css('h1', text: '変更後のツリー名')
     find('a', text: 'ツリー一覧').click
-    expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: '変更後のツリー名')
+    expect(page).to have_selector('.tree-name', text: '変更後のツリー名')
   end
 
   it '新規作成したツリーのノードを編集して保存できる' do

--- a/spec/system/trees/trees_index_spec.rb
+++ b/spec/system/trees/trees_index_spec.rb
@@ -31,17 +31,15 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
     end
 
     it 'ツリーの一覧が表示されること' do
-      expect(page).to have_table
-      expect(page).to have_selector('table > tbody > tr', count: 3)
-      expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー1')
-      expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー2')
-      expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー3')
-      tree_times.reverse.each_with_index do |time, index|
-        formatted_time = time.strftime('%Y-%m-%d %H:%M:%S')
-        expect(page).to have_selector("table > tbody > tr:nth-child(#{index + 1}) > td.td-tree-updated-at",
-                                      text: formatted_time)
+      expect(page).to have_selector('.tree-name', count: 3)
+      expect(page).to have_selector('.tree-name', text: 'ツリー1')
+      expect(page).to have_selector('.tree-name', text: 'ツリー2')
+      expect(page).to have_selector('.tree-name', text: 'ツリー3')
+      tree_times.each do |time|
+        formatted_time = time.strftime('%Y年%m月%d日 %H:%M')
+        expect(page).to have_selector('.tree-updated-at', text: formatted_time)
       end
-      expect(page).to have_selector('table > tbody > tr > td.td-tree-action > button', text: '編集', count: 3)
+      expect(page).to have_selector('.tree-action > button', text: '編集', count: 3)
     end
 
     it '一覧のツリーがlatest_update_atの降順に並んでいること' do
@@ -49,9 +47,9 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       # tree1内のノードのupdated_atを更新してtree1の最終更新が最新になるようにする（tree1, tree3, tree2の順)
       tree1_new_node = create(:node, name: 'ルート', tree_id: tree1.id, updated_at: 1.hour.ago)
       visit root_path
-      timestamps = page.all('table > tbody > tr > td.td-tree-updated-at').map(&:text)
+      timestamps = page.all('tree-updated-at').map(&:text)
       expect_timestamps = [tree1_new_node.updated_at, tree3.updated_at, tree2.updated_at].map do |ts|
-        ts.strftime('%Y-%m-%d %H:%M:%S')
+        ts.strftime('%Y年%m月%d日 %H:%M')
       end
       timestamps.each_with_index do |timestamp, index|
         expect(timestamp).to eq(expect_timestamps[index])
@@ -60,13 +58,13 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
 
     it 'ツリー名をクリックすると、そのツリーの編集画面に遷移すること' do
       most_recent_updated_tree = user.trees.order_by_latest_updated_at.first
-      page.all('table > tbody > tr > td.td-tree-name > a').first.click
+      page.all('.tree-name > a').first.click
       expect(page).to have_current_path(edit_tree_path(most_recent_updated_tree))
     end
 
     it '編集ボタンをクリックすると、そのツリーの編集画面に遷移すること' do
       most_recent_updated_tree = user.trees.order_by_latest_updated_at.first
-      page.all('table > tbody > tr > td.td-tree-action > button', text: '編集').first.click
+      page.all('.tree-action > button', text: '編集').first.click
       expect(page).to have_current_path(edit_tree_path(most_recent_updated_tree))
     end
   end
@@ -91,7 +89,7 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
         create(:tree, name: "ツリー#{i + 1}", user_id: user.id)
       end
       visit root_path
-      expect(page).to have_selector('table > tbody > tr', count: 10)
+      expect(page).to have_selector('.tree-name', count: 10)
     end
 
     it 'ページネーションのNextをクリックすると、ツリー一覧が切り替わること' do
@@ -100,8 +98,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       end
       visit root_path
       click_link 'Next >'
-      expect(page).to have_selector('table > tbody > tr', count: 10)
-      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー11')
+      expect(page).to have_selector('.tree-name', count: 10)
+      expect(first('.tree-name').text).to eq('ツリー11')
     end
 
     it 'ページネーションのPreviousをクリックすると、ツリー一覧が切り替わること' do
@@ -110,8 +108,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       end
       visit "#{root_path}?page=2"
       click_link '< Prev'
-      expect(page).to have_selector('table > tbody > tr', count: 10)
-      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー1')
+      expect(page).to have_selector('.tree-name', count: 10)
+      expect(first('.tree-name').text).to eq('ツリー1')
     end
 
     it 'ページネーションのFirstをクリックすると、ツリー一覧が切り替わること' do
@@ -120,8 +118,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       end
       visit "#{root_path}?page=3"
       click_link '<< First'
-      expect(page).to have_selector('table > tbody > tr', count: 10)
-      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー1')
+      expect(page).to have_selector('.tree-name', count: 10)
+      expect(first('.tree-name').text).to eq('ツリー1')
     end
 
     it 'ページネーションのLastをクリックすると、ツリー一覧が切り替わること' do
@@ -130,8 +128,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       end
       visit root_path
       click_link 'Last >>'
-      expect(page).to have_selector('table > tbody > tr', count: 1)
-      expect(first('table > tbody > tr > td.td-tree-name').text).to eq('ツリー31')
+      expect(page).to have_selector('.tree-name', count: 1)
+      expect(first('.tree-name').text).to eq('ツリー31')
     end
   end
 
@@ -145,33 +143,33 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       end
 
       it 'ツリーの削除ボタンをクリックすると、削除実行確認モーダルが開くこと' do
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
-                                                                                              text: '削除').click
+        find('.tree-name > a', text: 'ツリー1').ancestor('.tree').find('.tree-action > label',
+                                                                       text: '削除').click
         expect(page).to have_content('ツリー1を削除してよろしいですか？')
       end
 
       it '削除実行確認モーダルでキャンセルをクリックすると、モーダルが閉じること' do
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
-                                                                                              text: '削除').click
+        find('.tree-name > a', text: 'ツリー1').ancestor('.tree').find('.tree-action > label',
+                                                                       text: '削除').click
         find('label', text: 'キャンセル').click
         expect(page).not_to have_content('ツリー1を削除してよろしいですか？')
       end
 
       it '削除を実行するとツリーが削除され、ツリー一覧から消えること' do
-        expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー1')
-        expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー2')
+        expect(page).to have_selector('.tree-name', text: 'ツリー1')
+        expect(page).to have_selector('.tree-name', text: 'ツリー2')
         expect(Tree.where(user_id: user.id).count).to eq(2)
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
-                                                                                              text: '削除').click
+        find('.tree-name > a', text: 'ツリー1').ancestor('.tree').find('.tree-action > label',
+                                                                       text: '削除').click
         click_button '削除する'
         expect(Tree.where(user_id: user.id).count).to eq(1)
-        expect(page).not_to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー1')
-        expect(page).to have_selector('table > tbody > tr > td.td-tree-name', text: 'ツリー2')
+        expect(page).not_to have_selector('.tree-name', text: 'ツリー1')
+        expect(page).to have_selector('.tree-name', text: 'ツリー2')
       end
 
       it '削除の実行が完了すると、削除完了メッセージが表示されること' do
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
-                                                                                              text: '削除').click
+        find('.tree-name > a', text: 'ツリー1').ancestor('.tree').find('.tree-action > label',
+                                                                       text: '削除').click
         click_button '削除する'
         expect(page).to have_content(I18n.t('messages.tree_destroyed', target_tree_name: 'ツリー1'))
       end
@@ -185,8 +183,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
         expect(Tree.where(user_id: user.id).count).to eq(2)
         expect(Node.where(tree_id: tree1.id).count).to eq(3)
         expect(Layer.where(tree_id: tree1.id).count).to eq(1)
-        find('table > tbody > tr > td.td-tree-name > a', text: 'ツリー1').ancestor('tr').find('td.td-tree-action > label',
-                                                                                              text: '削除').click
+        find('.tree-name > a', text: 'ツリー1').ancestor('.tree').find('.tree-action > label',
+                                                                       text: '削除').click
         click_button '削除する'
         expect(Tree.where(user_id: user.id).count).to eq(1)
         expect(Node.where(tree_id: tree1.id).count).to eq(0)
@@ -198,7 +196,7 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       it 'ツリーの削除を実行したあと、ツリーが0件になったときは、ツリー一覧が表示されず、ツリー作成ボタンが表示されること' do
         create(:tree, name: '1件だけのツリー', user_id: user.id)
         visit root_path
-        page.all('table > tbody > tr > td.td-tree-action > label', text: '削除').first.click
+        page.all('.tree-action > label', text: '削除').first.click
         click_button '削除する'
         expect(page).to have_content(I18n.t('messages.tree_destroyed', target_tree_name: '1件だけのツリー'))
         expect(page).to have_content('まだツリーがありません。')
@@ -211,8 +209,8 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       it '404エラーページが表示されること' do
         tree = create(:tree, name: '削除されるツリー', user_id: user.id)
         visit root_path
-        find('table > tbody > tr > td.td-tree-name > a', text: '削除されるツリー').ancestor('tr').find(
-          'td.td-tree-action > label', text: '削除'
+        find('.tree-name > a', text: '削除されるツリー').ancestor('.tree').find(
+          '.tree-action > label', text: '削除'
         ).click
         tree.destroy!
         click_button '削除する'


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/266

close #266 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー一覧の表示レイアウトを修正した。
SP表示でも見やすいように、tableを使わない形に変更。
また、それに伴って影響のあるテストを修正した。

## 動作確認方法

- ログインし、ツリー一覧画面（`/`）にアクセスする
- ツリー一覧のレイアウトが変更後のものになっていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

PC幅：
![スクリーンショット 2023-10-26 15 16 11](https://github.com/peno022/kpi-tree-generator/assets/40317050/fd6e8d78-f531-4e7d-8785-717f7f8e48ce)

SP幅：

<img height="500" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/0820ea7d-0e23-4444-9884-f92da5331086">

### 変更後

PC幅：

![スクリーンショット 2023-10-26 15 15 40](https://github.com/peno022/kpi-tree-generator/assets/40317050/4d1da906-224b-492e-84d1-62459912e076)

SP幅：

<img height="500" src="https://github.com/peno022/kpi-tree-generator/assets/40317050/5f678740-18cc-47bf-afa0-634294310a35">