### PR TITLE
ツリー編集画面のツリーエリア・ツールエリアのデザインを調整

### DIFF
--- a/app/javascript/components/shared/OpenModalButton.tsx
+++ b/app/javascript/components/shared/OpenModalButton.tsx
@@ -19,7 +19,9 @@ const OpenModalButton: React.FC<OpenModalButtonProps> = ({
   modalButtonText,
   handleClick,
 }) => {
-  const buttonClass = `btn btn-primary ${disabled ? "btn-disabled" : ""}`;
+  const buttonClass = `btn btn-primary btn-sm border-emerald-700 bg-emerald-100 h-12 w-44 text-base ${
+    disabled ? "btn-disabled" : ""
+  }`;
   return (
     <>
       {/* The button to open modal */}

--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -10,6 +10,8 @@ import { useTreeUpdate } from "@/hooks/useTreeUpdate";
 import AlertError from "@/components/shared/AlertError";
 import useLayerToolLogic from "@/hooks/useLayerToolLogic";
 import useUpdateButtonStatus from "@/hooks/useUpdateButtonStatus";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
 
 type LayerToolProps = {
   selectedNodes: NodeFromApi[];
@@ -98,7 +100,7 @@ const LayerTool: React.FC<LayerToolProps> = ({
   return (
     <>
       <div className="relative flex flex-col h-full">
-        <div className="absolute inset-0 overflow-y-auto p-2 pb-20 tool">
+        <div className="absolute inset-0 overflow-y-auto p-4 pb-24 tool">
           {errorMessage && <AlertError message={errorMessage} />}
           <div className="flex justify-between">
             <div className="text-base font-semibold label-operation">
@@ -149,13 +151,17 @@ const LayerTool: React.FC<LayerToolProps> = ({
             />
           ))}
           <div className="flex justify-center">
-            <button className="btn btn-sm btn-outline mt-2" onClick={addNode}>
+            <button
+              className="btn btn-sm mt-2 border-gray-400 bg-slate-50"
+              onClick={addNode}
+            >
+              <FontAwesomeIcon icon={faPlus} />
               要素を追加
             </button>
           </div>
         </div>
         <div
-          className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-2"
+          className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-4"
           id="updateButton"
         >
           <OpenModalButton

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -32,10 +32,12 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
   return (
     <div className="relative">
       <fieldset
-        className="border border-base-300 p-2 my-2.5"
+        className="rounded-lg border border-base-300 p-2 my-2.5 bg-slate-50"
         id={`node-detail-${index + 1}`}
       >
-        <legend>{`要素${index + 1}`}</legend>
+        <legend className="bg-base-100 border border-base-300 rounded-xl text-sm font-bold flex items-center justify-center h-8 w-16">
+          {`要素 ${index + 1}`}
+        </legend>
         <div className="absolute right-0 top-2 mt-1.5">
           {!isRoot && (
             <ToolMenu

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeField.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeField.tsx
@@ -35,7 +35,11 @@ const NodeField: React.FC<Props> = ({
           type="checkbox"
           name={name}
           onChange={handleInputChange}
-          className={isValidField ? "checkbox" : "checkbox checkbox-error"}
+          className={
+            isValidField
+              ? "checkbox rounded-sm"
+              : "checkbox rounded-sm checkbox-error"
+          }
           checked={checked}
           id={`node-${index}-${name}`}
         />
@@ -86,7 +90,10 @@ const NodeField: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col">
-      <label htmlFor={`node-${index}-${name}`} className="text-sm">
+      <label
+        htmlFor={`node-${index}-${name}`}
+        className={`text-sm ${type === "checkbox" ? "cursor-pointer" : ""}`}
+      >
         {label}
       </label>
       {inputElement}

--- a/app/javascript/components/trees/tool/operationArea/Operation.tsx
+++ b/app/javascript/components/trees/tool/operationArea/Operation.tsx
@@ -11,13 +11,20 @@ const Operation: React.FC<OperationProps> = ({
   operation,
   onClick,
 }) => {
-  const styleSelected = "bg-base-100 border border-neutral";
-  const styleUnselected = "bg-base-200 text-base-300 border border-base-200";
+  const styleSelected = "bg-slate-50 border border-gray-400";
+  const styleUnselected = "bg-gray-200 text-gray-400 border border-gray-400";
+
+  const roundedMultiply = "rounded-l-md";
+  const roundedAdd = "rounded-r-md";
+  const borderMultiply = "border-r-0";
+
   return (
     <button
-      className={`w-28 h-8 text-center rounded ${
-        isSelected ? styleSelected : styleUnselected
-      }`}
+      className={`w-28 h-8 text-center ${
+        operation === "multiply"
+          ? `${roundedMultiply} ${borderMultiply}`
+          : roundedAdd
+      } ${isSelected ? styleSelected : styleUnselected}`}
       onClick={onClick}
     >
       {operation === "multiply" ? "かけ算" : "たし算"}

--- a/app/javascript/components/trees/tool/operationArea/Operations.tsx
+++ b/app/javascript/components/trees/tool/operationArea/Operations.tsx
@@ -22,7 +22,7 @@ const Operations: React.FC<OperationsProps> = ({
   }, [selectedLayer]);
 
   return (
-    <div className="flex space-x-4">
+    <div className="flex">
       <div>
         <Operation
           isSelected={selected === "multiply"}

--- a/app/javascript/components/trees/tree/CustomNode.tsx
+++ b/app/javascript/components/trees/tree/CustomNode.tsx
@@ -79,14 +79,14 @@ const CustomNode = ({
                 ? {
                     width: "200",
                     height: "100",
-                    fill: "moccasin",
-                    stroke: "dimgray",
+                    fill: "#D1FAE5", // bg-emerald-100 rgb(209, 250, 229)
+                    stroke: "#047857", // border-emerald-700
                     strokeWidth: "1",
                   }
                 : {
                     width: "200",
                     height: "100",
-                    fill: "ghostwhite",
+                    fill: "#F8FAFC", // bg-slate-50 rgb(248, 250, 252)
                     stroke: "dimgray",
                     strokeWidth: "1",
                   }

--- a/spec/javascript/components/trees/tool/Operation.spec.tsx
+++ b/spec/javascript/components/trees/tool/Operation.spec.tsx
@@ -6,6 +6,10 @@ import Operation, {
 } from "@/components/trees/tool/operationArea/Operation";
 
 describe("Operation", () => {
+  const activeButtonClass = "bg-slate-50 border border-gray-400";
+  const inActiveButtonClass =
+    "bg-gray-200 text-gray-400 border border-gray-400";
+
   it("かけ算・選択状態のとき", () => {
     const operationProps: OperationProps = {
       isSelected: true,
@@ -14,9 +18,7 @@ describe("Operation", () => {
     };
     render(<Operation {...operationProps} />);
     const operationButton = screen.getByRole("button");
-    expect(operationButton).toHaveClass("bg-base-100");
-    expect(operationButton).toHaveClass("border");
-    expect(operationButton).toHaveClass("border-neutral");
+    expect(operationButton).toHaveClass(activeButtonClass);
     expect(operationButton).toHaveTextContent("かけ算");
   });
 
@@ -28,9 +30,7 @@ describe("Operation", () => {
     };
     render(<Operation {...operationProps} />);
     const operationButton = screen.getByRole("button");
-    expect(operationButton).toHaveClass("bg-base-200");
-    expect(operationButton).toHaveClass("text-base-300");
-    expect(operationButton).toHaveClass("border");
+    expect(operationButton).toHaveClass(inActiveButtonClass);
     expect(operationButton).toHaveTextContent("かけ算");
   });
 

--- a/spec/javascript/components/trees/tool/ToolArea.spec.tsx
+++ b/spec/javascript/components/trees/tool/ToolArea.spec.tsx
@@ -14,27 +14,27 @@ function getNodeField(
   switch (fieldName) {
     case "名前": {
       return within(
-        screen.getByRole("group", { name: `要素${index}` })
+        screen.getByRole("group", { name: `要素 ${index}` })
       ).getByRole("textbox", { name: "名前" });
     }
     case "数値": {
       return within(
-        screen.getByRole("group", { name: `要素${index}` })
+        screen.getByRole("group", { name: `要素 ${index}` })
       ).getByRole("textbox", { name: "数値" });
     }
     case "単位": {
       return within(
-        screen.getByRole("group", { name: `要素${index}` })
+        screen.getByRole("group", { name: `要素 ${index}` })
       ).getByRole("textbox", { name: "単位" });
     }
     case "表示形式": {
       return within(
-        screen.getByRole("group", { name: `要素${index}` })
+        screen.getByRole("group", { name: `要素 ${index}` })
       ).getByRole("combobox", { name: "表示形式" });
     }
     case "数値を自動更新しない": {
       return within(
-        screen.getByRole("group", { name: `要素${index}` })
+        screen.getByRole("group", { name: `要素 ${index}` })
       ).getByRole("checkbox", { name: "数値を自動更新しない" });
     }
   }
@@ -111,15 +111,15 @@ describe("選択したノードが子ノードのとき", () => {
       render(<ToolArea {...toolAreaProps} />);
 
       expect(screen.getByText("要素間の関係")).toBeInTheDocument();
+      const activeButtonClass = "bg-slate-50 border border-gray-400";
+      const inActiveButtonClass =
+        "bg-gray-200 text-gray-400 border border-gray-400";
       const multiplyButton = screen.getByRole("button", { name: "かけ算" });
       expect(multiplyButton).toBeInTheDocument();
-      const activeButtonClass =
-        "bg-base-200 text-base-300 border border-base-200";
-      expect(multiplyButton).toHaveClass(activeButtonClass);
+      expect(multiplyButton).toHaveClass(inActiveButtonClass);
       const addButton = screen.getByRole("button", { name: "たし算" });
       expect(addButton).toBeInTheDocument();
-      const inActiveButtonClass = "bg-base-100 border border-neutral";
-      expect(addButton).toHaveClass(inActiveButtonClass);
+      expect(addButton).toHaveClass(activeButtonClass);
     });
 
     it("親子ノード間の計算式が表示されていること", () => {

--- a/spec/system/trees/tree_create_new_children_spec.rb
+++ b/spec/system/trees/tree_create_new_children_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'ツリー上で葉ノードに子階層を追加する', :js, :l
       created_nodes = all('g.custom-node', text: '新規の要素')
       expect(created_nodes.size).to eq 2
       created_nodes.each do |node|
-        expect(node.find('rect')[:style]).to include('fill: moccasin')
+        expect(node.find('rect')[:style]).to include('fill: rgb(209, 250, 229)')
       end
       expect_node_detail(
         index: 1, name: '新規の要素', value: '1', value_format: 'なし', unit: '', is_value_locked: false

--- a/spec/system/trees/tree_show_spec.rb
+++ b/spec/system/trees/tree_show_spec.rb
@@ -2,7 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ツリーを表示', :js do
+RSpec.describe 'ツリーを表示', :js do\
+  node_selected_style_fill = 'fill: rgb(209, 250, 229)'
+  node_not_selected_style_fill = 'fill: rgb(248, 250, 252)'
+
   before do
     visit log_out_path
     visit root_path
@@ -33,13 +36,13 @@ RSpec.describe 'ツリーを表示', :js do
   it 'treeの子ノードをクリックすると、兄弟ノードの色が変わり、ノード詳細が要素のid順で表示される。' do
     target_node_before = find('g > text', text: '子1').ancestor('g.custom-node')
     sibling_node_before = find('g > text', text: '子2').ancestor('g.custom-node')
-    expect(target_node_before.find('rect')[:style]).to include('fill: ghostwhite')
-    expect(sibling_node_before.find('rect')[:style]).to include('fill: ghostwhite')
+    expect(target_node_before.find('rect')[:style]).to include(node_not_selected_style_fill)
+    expect(sibling_node_before.find('rect')[:style]).to include(node_not_selected_style_fill)
     target_node_before.click
     target_node_after = find('g > text', text: '子1').ancestor('g.custom-node')
-    expect(target_node_after.find('rect')[:style]).to include('fill: moccasin')
+    expect(target_node_after.find('rect')[:style]).to include(node_selected_style_fill)
     sibling_node_after = find('g > text', text: '子2').ancestor('g.custom-node')
-    expect(sibling_node_after.find('rect')[:style]).to include('fill: moccasin')
+    expect(sibling_node_after.find('rect')[:style]).to include(node_selected_style_fill)
 
     # ツールエリアにクリックしたノードの階層の詳細が表示されていること
     expect(page).to have_content('要素間の関係')
@@ -55,13 +58,13 @@ RSpec.describe 'ツリーを表示', :js do
 
     # クリックしたルートノードの色が変わること
     target_node_before = find('g > text', text: 'ルート').ancestor('g.custom-node')
-    expect(target_node_before.find('rect')[:style]).to include('fill: ghostwhite')
+    expect(target_node_before.find('rect')[:style]).to include(node_not_selected_style_fill)
     target_node_before.click
     target_node_after = find('g > text', text: 'ルート').ancestor('g.custom-node')
-    expect(target_node_after.find('rect')[:style]).to include('fill: moccasin')
+    expect(target_node_after.find('rect')[:style]).to include(node_selected_style_fill)
 
     # ツールエリアにクリックしたノードの階層の詳細が表示されていること
-    expect(page).to have_content('要素1')
+    expect(page).to have_content('要素 1')
     expect(page).not_to have_content('要素間の関係')
     expect(page).to have_css('input[value="ルート"]')
   end

--- a/spec/system/trees/tree_update_spec.rb
+++ b/spec/system/trees/tree_update_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
 
       # 要素未選択状態に戻り、ツールエリアが閉じていることを確認
       all('g.custom-node > rect').each do |rect|
-        expect(rect[:style]).not_to include('fill: moccasin')
+        expect(rect[:style]).not_to include('fill: #D1FAE5')
       end
       expect(find_by_id('toolWrapper')).to have_content('要素を選択すると、ここに詳細が表示されます。')
     end
@@ -317,7 +317,8 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
       click_button 'たし算'
       find('g.custom-node', text: '子1').hover
       expect(find_by_id('node-detail-1').find('input[name="name"]').value).to eq '変更後のノード名1'
-      expect(page).to have_button('たし算', class: 'bg-base-100 border border-neutral')
+      active_operation_button_styles = 'bg-slate-50 border border-gray-400'
+      expect(page).to have_button('たし算', class: active_operation_button_styles)
     end
 
     it '項目を編集してからツリー上で任意のノードをクリックすると、編集内容は失われてクリックしたノードを含む階層の情報でツールエリアが表示される' do
@@ -326,7 +327,8 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
       find('g.custom-node', text: '子1').click
       expect(find_by_id('node-detail-1').find('input[name="name"]').value).not_to eq '変更後のノード名1'
       expect(find_by_id('node-detail-1').find('input[name="name"]').value).to eq '子1'
-      expect(page).to have_button('かけ算', class: 'bg-base-100 border border-neutral')
+      active_operation_button_styles = 'bg-slate-50 border border-gray-400'
+      expect(page).to have_button('かけ算', class: active_operation_button_styles)
     end
 
     it '親ノードの数値と合わない状態で！アイコンが表示されているノードについて、数値が合うように編集して更新すると！アイコンが消える' do
@@ -474,7 +476,8 @@ RSpec.describe '階層・ノードのプロパティを編集・更新', :js, :l
     end
 
     it '追加された要素のデフォルトの数値値が、階層内の要素間の関係ごとに設定されている。' do
-      expect(page).to have_button('かけ算', class: 'bg-base-100 border border-neutral')
+      active_operation_button_styles = 'bg-slate-50 border border-gray-400'
+      expect(page).to have_button('かけ算', class: active_operation_button_styles)
       click_button '要素を追加'
       expect(page).to have_selector('#node-detail-3 input[name="value"][value="1"]')
       click_button 'たし算'


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/272
- https://github.com/peno022/kpi-tree-generator/issues/273
- https://github.com/peno022/kpi-tree-generator/issues/274

close #272 
close #273 
close #274

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

デザインレビュー指摘対応。ツリー編集画面のツリーエリア・ツールエリアのデザインを調整した。

- ツリー図のノードの色を変更
- ツールエリアのかけ算／たし算ボタンのスタイルを変更
  - 選択・非選択時の色を変更
  - 2つのボタンをくっつける
- ツールエリア全体のpaddingを変更
- 要素を追加ボタンのスタイルを変更
  - 色を変更
  - アイコンを追加
- 更新ボタンの色とサイズを変更
- ツールエリアの各ノード詳細のスタイルを変更
  - 「要素1」→「要素 1」のように、数値の前に半角スペースを入れる
  - 「要素1」の部分を白角丸で囲む
  - 「数値を自動更新しない」のチェックボックスの角丸サイズを変更、ラベルホバー時もポインタカーソルにするように変更
  - 背景色を変更
  - 外枠を角丸に変更

併せて、上記変更が影響するテストを修正。

## 動作確認方法

ログインして任意のツリーの編集画面（`/trees/xx/edit`）を表示し、デザイン変更が適用されていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

|   | 変更前 | 変更後  |
|---|--------|---|
| 幅1280px |   ![localhost_3000_trees_46_edit (2)](https://github.com/peno022/kpi-tree-generator/assets/40317050/fc0d1ab7-c225-4be8-a10e-1d072490c11c)   | ![localhost_3000_trees_46_edit](https://github.com/peno022/kpi-tree-generator/assets/40317050/beacc3d0-ac65-4898-985e-4826c6dceb83)  |
| 幅2800px |   ![localhost_3000_trees_46_edit (3)](https://github.com/peno022/kpi-tree-generator/assets/40317050/65afa702-b7c9-4983-b940-3c078e485809)   | ![localhost_3000_trees_46_edit (1)](https://github.com/peno022/kpi-tree-generator/assets/40317050/169564c9-6846-4dd1-8f3d-6c0ef5649254)  |
| 幅390px | ![localhost_3000_trees_46_edit(iPhone 12 Pro) (2)](https://github.com/peno022/kpi-tree-generator/assets/40317050/7655675f-a0b6-4b70-b930-484ded3d5414)  |  ![localhost_3000_trees_46_edit(iPhone 12 Pro) (1)](https://github.com/peno022/kpi-tree-generator/assets/40317050/335eecf9-0e84-4d57-967d-24b5279d2d4f) |
| 幅390px（下までスクロール） | ![screencapture-localhost-3000-trees-46-edit-2023-10-29-14_45_48](https://github.com/peno022/kpi-tree-generator/assets/40317050/d49b04f7-c922-48ec-bacd-49e1b2e8a5d0) | ![screencapture-localhost-3000-trees-46-edit-2023-10-29-14_44_32](https://github.com/peno022/kpi-tree-generator/assets/40317050/990c70d4-206d-4bf6-8483-4b63b082289b) |