### PR TITLE
simplecavを導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@
 /terraform/.terraform
 /terraform/.terraform/*
 /terraform/terraform.tfvars
+/coverage
+/coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -80,4 +80,5 @@ group :test do
   gem 'capybara'
   gem 'launchy'
   gem 'selenium-webdriver'
+  gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dockerfile-rails (1.5.9)
       rails
     erubi (1.12.0)
@@ -305,6 +306,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     slim (5.1.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
@@ -370,6 +377,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
+  simplecov
   slim-rails
   slim_lint
   tzinfo-data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/293

close #293 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

テストカバレッジ計測ツールとして Simplecav の gem を導入した。

## 動作確認方法

- `bundle exec rspec`でテストを実行
- coverage/index.html が存在すること、ブラウザで開いてテストレポートの内容が閲覧できることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

割愛

### 変更後

テストレポートが確認できた。

![スクリーンショット 2023-10-29 15 52 19](https://github.com/peno022/kpi-tree-generator/assets/40317050/f3916d9d-4d01-4e64-b71d-1ffacccc198a)
![スクリーンショット 2023-10-29 15 52 36](https://github.com/peno022/kpi-tree-generator/assets/40317050/2190c2e6-a9ab-4a8a-b9ad-195af5f65d70)