### PR TITLE
画像ダウンロードボタンのデザインを修正

### DIFF
--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -24,9 +24,9 @@
             = link_to(log_out_path) do
               i.fa-solid.fa-right-from-bracket
               | ログアウト
-    .hidden.md:block
-      ul.menu.menu-horizontal.px-2.md:px-6
-        a.btn.btn-outline.mx-4 data-action="download-image"
+    .hidden.md:block.flex
+      ul.menu.menu-horizontal.px-2.md:px-6.items-center
+        a.btn.btn-sm.border-neutral.bg-slate-50.h-9.mx-4 data-action="download-image"
           | 画像ダウンロード
         - if current_user
             .dropdown.dropdown-end


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/275

close  #275 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー編集画面の画像ダウンロードボタンのデザインを修正した。

## 動作確認方法

ログインして任意のツリーの編集画面（`/trees/xxx/edit`)にアクセスし、ヘッダー右側の画像ダウンロードボタンにデザイン修正が適用されていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-10-29 16 39 19](https://github.com/peno022/kpi-tree-generator/assets/40317050/91b7f545-e160-4246-9bfa-b8b9c8b9358a)

### 変更後

![スクリーンショット 2023-10-29 16 38 38](https://github.com/peno022/kpi-tree-generator/assets/40317050/40b22960-1e60-48cb-b3b3-b03c5bcffb10)