### PR TITLE
ルートノード選択時の更新ボタンの余白を修正

### DIFF
--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -71,7 +71,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
     <>
       <div className="relative flex flex-col h-full">
         {errorMessage && <AlertError message={errorMessage} />}
-        <div className="absolute inset-0 overflow-y-auto p-2 pb-20" id="tool">
+        <div className="absolute inset-0 overflow-y-auto p-2 pb-24" id="tool">
           <NodeDetail
             index={0}
             node={nodeInfo}
@@ -85,7 +85,7 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
           />
         </div>
         <div
-          className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-2"
+          className="absolute bottom-0 w-full flex justify-center items-center border-t-2 border-base-300 bg-base-100 mt-auto p-4"
           id="updateButton"
         >
           <OpenModalButton


### PR DESCRIPTION
## Issue

下記issueでの考慮漏れがあり、追加修正。

- https://github.com/peno022/kpi-tree-generator/issues/273

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ルートノード選択時の「更新」ボタンの余白が狭いままになっていたので、子ノード選択時に揃える形で修正した。

## 動作確認方法

ログインして任意のツリーの編集画面（`/trees/xxx/edit`）にアクセスし、ルートノードを選択した時と子ノードを選択した時で更新ボタンの余白が同じになっていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-10-29 16 50 34](https://github.com/peno022/kpi-tree-generator/assets/40317050/b3c0ccf9-3a93-4c1c-b9a1-7a46b0a30736)

### 変更後

![スクリーンショット 2023-10-29 16 50 13](https://github.com/peno022/kpi-tree-generator/assets/40317050/5f6bdc9c-555a-4862-99c5-95e036de2194)