### PR TITLE
ツリー名編集のデザインを調整

### DIFF
--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -70,26 +70,30 @@ export const TreeName = () => {
       {isEditing ? (
         <>
           <div className="text-error">{errorMessage}</div>
-          <input
-            type="text"
-            className="input input-bordered input-primary w-full max-w-xs"
-            value={treeNameEditing}
-            onChange={handleTreeNameChange}
-            name="tree-name-input"
-            aria-label="tree-name-input"
-          />
-          <button
-            className="btn btn-ghost btn-sm edit-tree-name-ok"
-            onClick={handleTreeNameSubmit}
-          >
-            OK
-          </button>
-          <button
-            className="btn btn-ghost btn-sm edit-tree-name-cancel"
-            onClick={handleCancelEditButtonClick}
-          >
-            キャンセル
-          </button>
+          <div className="flex">
+            <div className="items-center">
+              <input
+                type="text"
+                className="input input-bordered max-w-xs h-10 mr-2.5"
+                value={treeNameEditing}
+                onChange={handleTreeNameChange}
+                name="tree-name-input"
+                aria-label="tree-name-input"
+              />
+              <button
+                className="btn btn-sm border-gray-400 bg-slate-50 edit-tree-name-ok h-9"
+                onClick={handleTreeNameSubmit}
+              >
+                OK
+              </button>
+              <button
+                className="btn btn-ghost btn-sm edit-tree-name-cancel"
+                onClick={handleCancelEditButtonClick}
+              >
+                キャンセル
+              </button>
+            </div>
+          </div>
         </>
       ) : (
         <>


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/276

close  #276 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー名編集のデザインを調整。

- 編集時に表示するテキストボックスの高さを小さくし、枠線からprimary色を外した
- OKボタンのスタイルを変更した
- テキストボックスとOKボタンとキャンセルボタンが縦中央に揃うようにした、また余白を調整した

## 動作確認方法

- ログインして任意のツリーの編集画面（`/trees/xxx/edit`）にアクセスする
- ヘッダーのツリー名右側に表示されている鉛筆アイコンをクリックし、ツリー名を編集状態にする
- デザイン修正が反映されていることを確認する
- ツリー名を編集してOKボタンを押し、更新が完了することを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-10-29 17 12 21](https://github.com/peno022/kpi-tree-generator/assets/40317050/87d75ca3-e870-43af-b2dd-8247b1f15449)

### 変更後

![スクリーンショット 2023-10-29 17 11 21](https://github.com/peno022/kpi-tree-generator/assets/40317050/fda04c99-508d-4169-9f53-85f543fbeb37)