### PR TITLE
ツリー一覧画面のボタンデザインを修正

### DIFF
--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -7,7 +7,7 @@
         |ツリー一覧
       - if @trees.any?
         = button_to '新規作成', create_and_edit_trees_path, method: :post,
-        class: 'btn btn-sm my-2 ml-10'
+        class: 'btn btn-primary btn-sm border-emerald-700 bg-emerald-100 h-9 w-28 text-base my-2 ml-10'
     - if @trees.any?
       .overflow-x-auto.m-3.trees
         - @trees.each do |tree|
@@ -16,7 +16,7 @@
               .tree-name.p-2.text-lg.w-2/3
                 = link_to tree.name, edit_tree_path(tree)
               .tree-action.w-1/3.flex.justify-center
-                button.btn.btn-sm.mx-1
+                button.btn.btn-sm.mx-1.border-gray-400.bg-slate-50
                   = link_to edit_tree_path(tree) do
                     | 編集
                 label.btn.btn-sm.mr-1.btn-ghost[for="tree_delete_confirm_#{tree.id}"]

--- a/app/views/trees/index.html.slim
+++ b/app/views/trees/index.html.slim
@@ -43,4 +43,4 @@
         .text-lg.mb-4
           | まだツリーがありません。
         = button_to 'ツリーを作成する', create_and_edit_trees_path, method: :post,
-          class: 'btn btn-primary my-2'
+          class: 'btn btn-primary my-2 border-emerald-700 bg-emerald-100 text-base'


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/278

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー一覧画面の「新規作成」ボタンと「編集」ボタンのデザインを修正した。
新規作成ボタンはツリー編集画面の「更新」ボタンと、編集ボタンはツリー編集画面の「要素を追加」ボタンとあわせた色にした。

## 動作確認方法

ログインし、ツリー一覧画面（'/'）を表示する。
ツリーが0件のときとツリーが1件のときそれぞれで、ツリー一覧画面の新規作成ボタンと編集ボタンにデザイン修正が適用されていることを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-10-29 17 34 42](https://github.com/peno022/kpi-tree-generator/assets/40317050/741e5a50-940b-42ef-bf88-45ffaceea9bf)

![スクリーンショット 2023-10-29 17 34 32](https://github.com/peno022/kpi-tree-generator/assets/40317050/87b217c1-5b6a-4630-a642-696547cfeb29)

### 変更後

![スクリーンショット 2023-10-29 17 35 00](https://github.com/peno022/kpi-tree-generator/assets/40317050/f2c0f32a-7132-4672-ab08-0e595226274d)

![スクリーンショット 2023-10-29 17 34 12](https://github.com/peno022/kpi-tree-generator/assets/40317050/7ba73799-57ba-4393-a91d-433f9581124f)