### PR TITLE
トップページに配置しているサービスロゴの最大幅を設定

### DIFF
--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -9,7 +9,7 @@
           | KPI ツリーを
           br
           | かんたん作成
-        .py-6.flex.items-center.justify-center.md:w-3/5.w-5/6.mx-auto
+        .py-6.flex.items-center.justify-center.md:w-3/5.w-5/6.mx-auto.max-w-3xl
           = image_tag 'ktg-logo.svg', alt: 'KPI TREE MAKER logo', class: 'ktg-logo-image'
         .problems
           .container.mx-auto.md:w-3/4.p-16


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/268

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

トップページ中央のサービスロゴが、画面幅が大きい時にかなり大きく表示されている状態だったので、最大幅を設定した。

## 動作確認方法

ログインせずにトップページにアクセスし、ブラウザの画面幅を広げても画面中央のサービスロゴが最大幅以上に広がらないことを確認する。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![screencapture-localhost-3000-2023-10-29-17_50_10](https://github.com/peno022/kpi-tree-generator/assets/40317050/06011ed2-d092-4d30-a347-68425867cbcd)

### 変更後

![screencapture-localhost-3000-2023-10-29-17_49_53](https://github.com/peno022/kpi-tree-generator/assets/40317050/bdf1ebbb-caed-451a-8b86-b213d8e64e1f)