### PR TITLE
トップページのヘッダーをなくし、ログイン導線を修正する

### DIFF
--- a/app/views/welcome/_signup.html.slim
+++ b/app/views/welcome/_signup.html.slim
@@ -1,0 +1,21 @@
+.text-center
+  = button_to 'サインアップ（無料）', \
+  '/auth/google_oauth2', \
+  method: :post, \
+  data: { turbo: false }, \
+  class: 'btn btn-primary btn-lg'
+  .text-xs.text-neutral.mt-4.md:hidden
+    | ご利用には Google アカウントが必要です。
+    br
+    | サインアップによって、利用規約・プライバシー
+    br
+    | ポリシーに同意したものとみなします。
+  .text-xs.text-neutral.mt-4.hidden.md:block
+    | ご利用には Google アカウントが必要です。
+    br
+    | サインアップによって、利用規約・プライバシーポリシーに同意したものとみなします。
+  = button_to 'ログインはこちら', \
+  '/auth/google_oauth2', \
+  method: :post, \
+  data: { turbo: false }, \
+  class: 'btn btn-sm btn-link ml-auto text-accent mt-4 md:mt-6'

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,27 +1,21 @@
 - title 'KPI ツリーをかんたん作成'
-= render 'header'
-.flex.flex-col.min-h-screen.bg-neutral-content.pt-20.w-full
-  .mx-auto.mt-10.flex-grow
+.flex.flex-col.min-h-screen.bg-neutral-content.w-full
+  = button_to 'ログイン', \
+    '/auth/google_oauth2', \
+    method: :post, \
+    data: { turbo: false }, \
+    class: 'btn btn-sm btn-outline ml-auto btn-accent mx-4 mt-4 h-10 hidden md:block'
+  .mx-auto.flex-grow
     .text-center.object-center
-      .pb-10.flex.items-center.justify-center.md:w-3/5.w-5/6.mx-auto.max-w-3xl
+      .pb-10.flex.items-center.justify-center.md:w-3/5.w-5/6.mx-auto.max-w-3xl.mt-8.md:mt-0
         = image_tag 'ktg-logo.svg', alt: 'KPI TREE MAKER logo', class: 'ktg-logo-image'
       h1.text-2xl.md:text-4xl.font-bold.text-neutral.mb-2
         | KPI ツリーをかんたん作成
       .tree-sample
         .container.mx-auto.p-2.md:w-3/4.md:p-16
           = image_tag 'top-kpi-tree-screen-sample.svg', alt: 'KPIツリーメーカー画面', class: 'kpi-tree-screen-sample'
-          .text-center.pt-12.md:pt-16
-            = button_to 'サインアップ（無料）', \
-              '/auth/google_oauth2', \
-              method: :post, \
-              data: { turbo: false }, \
-              class: 'btn btn-primary btn-lg'
-            .text-xs.text-neutral.mt-4
-              | ご利用には Google アカウントが必要です。
-              br
-              | サインアップによって、利用規約・プライバシー
-              br
-              | ポリシーに同意したものとみなします。
+          .pt-12.md:pt-16
+            = render 'welcome/signup'
 
   .features.bg-base-100.flex-grow.w-full
     .container.mx-auto.text-center.object-center.md:w-3/4.p-16
@@ -46,18 +40,8 @@
           = image_tag 'undraw-payment.svg', alt: 'もちろん無料のイメージ画像', class: 'w-40 h-32 mx-auto my-6'
           p.text-lg
             | すべての機能を無料でご利用いただけます。
-      .text-center.py-10.mx-auto.md:hidden
-        = button_to 'サインアップ（無料）', \
-        '/auth/google_oauth2', \
-        method: :post, \
-        data: { turbo: false }, \
-        class: 'btn btn-primary btn-lg'
-        .text-xs.text-neutral.mt-4
-          | ご利用には Google アカウントが必要です。
-          br
-          | サインアップによって、利用規約・プライバシー
-          br
-          | ポリシーに同意したものとみなします。
+      .py-10.mx-auto.md:hidden
+        = render 'welcome/signup'
   footer.footer.footer-center.p-10.bg-base-100.text-base-content.rounded.border-base-300.border-t
     .grid.grid-flow-col.gap-4
       = link_to '利用規約', terms_of_use_path, class: 'link link-hover'

--- a/spec/system/require_login_spec.rb
+++ b/spec/system/require_login_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe 'ページごとのログイン要否' do
       it 'ウェルカムページにアクセスできること' do
         visit welcome_path
         expect(page).to have_content('KPI ツリーをかんたん作成')
-        expect(page).to have_css('.avatar')
       end
 
       it '利用規約ページにアクセスできること' do

--- a/spec/system/trees/trees_index_spec.rb
+++ b/spec/system/trees/trees_index_spec.rb
@@ -247,5 +247,14 @@ RSpec.describe 'ツリー一覧', :js, :login_required do
       click_link 'ログアウト'
       expect(page).to have_button text: 'サインアップ（無料）'
     end
+
+    it 'ヘッダーのロゴをホバーするとホバー時用の画像が表示される' do
+      visit root_path
+      expect(page).to have_css('.ktg-logo-header-image-md', visible: :visible)
+      expect(page).to have_css('.ktg-logo-header-image-hovered-md', visible: :hidden)
+      find('.ktg-logo-md').hover
+      expect(page).to have_css('.ktg-logo-header-image-md', visible: :hidden)
+      expect(page).to have_css('.ktg-logo-header-image-hovered-md', visible: :visible)
+    end
   end
 end

--- a/spec/system/welcomes_spec.rb
+++ b/spec/system/welcomes_spec.rb
@@ -45,12 +45,9 @@ RSpec.describe 'Welcome pages' do
     expect(page).to have_selector 'h1', text: 'ツリー一覧'
   end
 
-  it 'ヘッダーのロゴをホバーするとホバー時用の画像が表示される' do
+  it 'ログインはこちらボタンからログイン完了するとツリー一覧ページに遷移する' do
     visit root_path
-    expect(page).to have_css('.ktg-logo-header-image-md', visible: :visible)
-    expect(page).to have_css('.ktg-logo-header-image-hovered-md', visible: :hidden)
-    find('.ktg-logo-md').hover
-    expect(page).to have_css('.ktg-logo-header-image-md', visible: :hidden)
-    expect(page).to have_css('.ktg-logo-header-image-hovered-md', visible: :visible)
+    click_button 'ログインはこちら'
+    expect(page).to have_selector 'h1', text: 'ツリー一覧'
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/271

close #271 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ログイン前トップページから、ヘッダーをなくした。
代わりにログインボタンを、画面右上（幅768px以上の時のみ表示）と、サインアップボタン下に配置した。

## 動作確認方法

- ログインしていない状態で'/'にアクセスし、トップページを表示する
- デザイン変更が反映されていることを確認する
- 画面右上とサインアップボタン下の両方のログインボタンからログインを完了できることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![screencapture-localhost-3000-2023-10-30-09_06_03](https://github.com/peno022/kpi-tree-generator/assets/40317050/059aedb2-1674-4075-8bf9-132849b2325c)

![screencapture-localhost-3000-2023-10-30-09_05_49](https://github.com/peno022/kpi-tree-generator/assets/40317050/8eb9e73c-d25e-47ad-8041-65761664d434)


### 変更後

![screencapture-localhost-3000-2023-10-30-09_05_10](https://github.com/peno022/kpi-tree-generator/assets/40317050/6791f78b-d4a3-4bf1-bf55-6295cfc5e864)

![screencapture-localhost-3000-2023-10-30-09_05_25](https://github.com/peno022/kpi-tree-generator/assets/40317050/9a66e4bc-d27c-4b21-87ef-248182b57da0)
