### PR TITLE
ツリー一覧のナビゲーションホバー時のスタイルを変更

### DIFF
--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,8 +1,8 @@
 - title @tree.name.to_s
 .flex.flex-col.min-h-screen
   nav.bg-base-100.flex.justify-between.items-center.border-b-2.border-base-300
-    = link_to root_path, class: 'btn btn-ghost' do
-      p.mx-1
+    = link_to root_path, class: 'hover:underline flex space-x-2 items-center font-bold mx-3' do
+      p
         i.fa.fa-lg.fa-angle-left[aria-hidden="true"]
         p.text-lg.hidden.md:block
           | ツリー一覧


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/304

close #304 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー作成画面のヘッダー左側の「ツリー一覧」のナビゲーションを hover した時のスタイルを変更。
daisyUI の btn クラスのスタイルで背景色が変わる状態だったが、変化が大きくて不自然だったため。
hover 時は背景色はそのままで下線が表示されるように変更した。

## 動作確認方法

1. ログインし、任意のツリーの作成画面を開く
1. 左上のツリー一覧をホバーすると下線が表示されることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-11-09 13 15 09](https://github.com/peno022/kpi-tree-generator/assets/40317050/8b8a23e7-a7ed-4f53-bf4a-7059ae5a7d84)

### 変更後

![スクリーンショット 2023-11-09 13 14 39](https://github.com/peno022/kpi-tree-generator/assets/40317050/7b8fb188-3488-44e7-a256-54201c893dc7)