### PR TITLE
ツリー名編集の鉛筆アイコンのスタイルを修正

### DIFF
--- a/app/javascript/pages/trees/TreeName.tsx
+++ b/app/javascript/pages/trees/TreeName.tsx
@@ -105,13 +105,18 @@ export const TreeName = () => {
           <h1 className="text-xl font-bold hidden md:block">
             {treeNameEditing}
           </h1>
-          <button
-            className="btn btn-ghost edit-tree-name-button"
-            aria-label="Edit tree name"
-            onClick={handleEditButtonClick}
-          >
-            <i className="fa fa-lg fa-pencil" aria-hidden="true"></i>
-          </button>
+          <div className="group">
+            <button
+              className="edit-tree-name-button mx-4"
+              aria-label="Edit tree name"
+              onClick={handleEditButtonClick}
+            >
+              <i
+                className="fa fa-pencil text-slate-500 group-hover:text-gray-400"
+                aria-hidden="true"
+              ></i>
+            </button>
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/305

close #305 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

ツリー作成画面のツリー名編集ボタン（鉛筆アイコンのボタン）がやや目立ちすぎて違和感があったため、色を薄く・サイズを小さくするように修正。
また、ホバー時には、背景色を変えるのではなく、アイコン色が薄くなるように修正した。

## 動作確認方法

1. ログインして任意のツリーの編集画面を表示
1. 画面上部のツリー名右側に表示されている鉛筆アイコンに、スタイルの変更が適用されていることを確認する
1. ホバーするとアイコンの色が薄くなることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

ホバー前

![スクリーンショット 2023-11-09 15 23 47](https://github.com/peno022/kpi-tree-generator/assets/40317050/716d2eef-6a39-4340-b421-1db8a5523ccc)


ホバー中

![スクリーンショット 2023-11-09 15 23 55](https://github.com/peno022/kpi-tree-generator/assets/40317050/0640c248-e50f-4170-ab5e-0e05cc4d225f)



### 変更後

ホバー前

![スクリーンショット 2023-11-09 15 23 01](https://github.com/peno022/kpi-tree-generator/assets/40317050/d239aee5-4b02-4f7a-866f-3959a8a21b25)

ホバー中

![スクリーンショット 2023-11-09 15 23 07](https://github.com/peno022/kpi-tree-generator/assets/40317050/a8260e8d-de85-456b-a402-705b75e2576f)
