### PR TITLE
ツールエリアのケバブメニューがアカウントメニューの上に重なって表示されているバグを修正

### DIFF
--- a/app/views/trees/edit.html.slim
+++ b/app/views/trees/edit.html.slim
@@ -1,6 +1,6 @@
 - title @tree.name.to_s
 .flex.flex-col.min-h-screen
-  nav.bg-base-100.flex.justify-between.items-center.border-b-2.border-base-300
+  nav.bg-base-100.flex.justify-between.items-center.border-b-2.border-base-300.relative.z-10
     = link_to root_path, class: 'hover:underline flex space-x-2 items-center font-bold mx-3' do
       p
         i.fa.fa-lg.fa-angle-left[aria-hidden="true"]


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/307

close #307 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

下記画像のように、アカウントメニューの上に意図せずケバブアイコンがのってしまっていたので、ヘッダーに`relative`クラスと`z-10`クラスを追加し、アカウントメニューのほうが上に表示されるように修正した。

![image](https://github.com/peno022/kpi-tree-generator/assets/40317050/11cd4fa0-770d-44b8-83d6-169009687f5c)


## 動作確認方法

1. ログインし、任意のツリーの編集画面を表示
1. 任意の子ノードをクリックして、右側に階層の詳細が表示された状態にする
1. 右上のアイコン画像をクリックし、アカウントメニューをひらく
1. アカウントメニューのうえに、ツールメニューの「…」アイコンが表示されていないことを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-11-09 16 04 46](https://github.com/peno022/kpi-tree-generator/assets/40317050/e2f78233-c58b-403f-a342-f1bdf8974621)

### 変更後

![スクリーンショット 2023-11-09 16 03 47](https://github.com/peno022/kpi-tree-generator/assets/40317050/f1d62182-8bcf-4ec7-811b-4be03cd7accc)
