### PR TITLE
ノード詳細のスタイルを調整

### DIFF
--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeDetail.tsx
@@ -32,10 +32,10 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
   return (
     <div className="relative">
       <fieldset
-        className="rounded-lg border border-base-300 p-2 my-2.5 bg-slate-50"
+        className="rounded border border-base-300 px-4 py-2 my-2.5 bg-slate-50"
         id={`node-detail-${index + 1}`}
       >
-        <legend className="bg-base-100 border border-base-300 rounded-xl text-sm font-bold flex items-center justify-center h-8 w-16">
+        <legend className="bg-base-100 border border-base-300 rounded text-sm font-bold flex items-center justify-center h-8 w-16">
           {`要素 ${index + 1}`}
         </legend>
         <div className="absolute right-0 top-2 mt-1.5">
@@ -50,7 +50,7 @@ const NodeDetail: React.FC<NodeDetailProps> = ({
             />
           )}
         </div>
-        <div className="flex flex-row space-x-4 mb-1.5">
+        <div className="flex flex-row space-x-4 mb-2.5">
           <NodeField
             type="text"
             name="name"

--- a/app/javascript/components/trees/tool/nodeDetailArea/NodeField.tsx
+++ b/app/javascript/components/trees/tool/nodeDetailArea/NodeField.tsx
@@ -30,15 +30,14 @@ const NodeField: React.FC<Props> = ({
   let inputElement: JSX.Element;
   switch (type) {
     case "checkbox": {
+      const baseInputClass = "checkbox rounded-sm mt-1";
       inputElement = (
         <input
           type="checkbox"
           name={name}
           onChange={handleInputChange}
           className={
-            isValidField
-              ? "checkbox rounded-sm"
-              : "checkbox rounded-sm checkbox-error"
+            isValidField ? baseInputClass : `${baseInputClass} checkbox-error`
           }
           checked={checked}
           id={`node-${index}-${name}`}
@@ -48,7 +47,7 @@ const NodeField: React.FC<Props> = ({
     }
     case "number":
     case "text": {
-      const baseInputClass = "input input-sm input-bordered w-32";
+      const baseInputClass = "input input-sm input-bordered w-32 rounded";
       const inputClass = isValidField
         ? baseInputClass
         : `${baseInputClass} input-error`;
@@ -67,7 +66,7 @@ const NodeField: React.FC<Props> = ({
       break;
     }
     case "dropdown": {
-      const baseSelectClass = "input input-sm input-bordered w-32";
+      const baseSelectClass = "input input-sm input-bordered w-32 rounded";
       const selectClass = isValidField
         ? baseSelectClass
         : `${baseSelectClass} select-error`;
@@ -92,7 +91,9 @@ const NodeField: React.FC<Props> = ({
     <div className="flex flex-col">
       <label
         htmlFor={`node-${index}-${name}`}
-        className={`text-sm ${type === "checkbox" ? "cursor-pointer" : ""}`}
+        className={`text-sm mb-1 ${
+          type === "checkbox" ? "cursor-pointer" : ""
+        }`}
       >
         {label}
       </label>


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/306

close #306 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ノード詳細の余白がやや詰まっていたので、余白を広げる形で調整した。
- 角丸を0.25remで統一した。

## 動作確認方法

1. ログインし、任意のツリーの編集画面を開く
1. 任意のノードをクリックし、ノード詳細を表示する
1. スタイルの変更が適用されていることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-11-09 17 16 38](https://github.com/peno022/kpi-tree-generator/assets/40317050/42cccb67-032d-4220-ba4f-82ea184558c7)

![screencapture-localhost-3000-trees-50-edit-2023-11-09-17_20_21](https://github.com/peno022/kpi-tree-generator/assets/40317050/19b921d2-b0a7-4fa4-b7c6-90d8c65a65fa)


### 変更後

![スクリーンショット 2023-11-09 17 15 45](https://github.com/peno022/kpi-tree-generator/assets/40317050/2156d577-6f6c-4b13-87f4-e9b70d752e01)

![screencapture-localhost-3000-trees-50-edit-2023-11-09-17_20_42](https://github.com/peno022/kpi-tree-generator/assets/40317050/06d6190f-cad4-4bec-a030-58f6bba8fc6d)


