### PR TITLE
利用規約・プライバシーポリシー画面にヘッダーを表示する

### DIFF
--- a/app/views/welcome/privacy_policy.slim
+++ b/app/views/welcome/privacy_policy.slim
@@ -1,7 +1,7 @@
 - title 'プライバシーポリシー'
 - description 'KPI ツリーメーカーにおける、ユーザーの個人情報の取扱いについて、このページにあるとおりプライバシーポリシーを定めます。'
-
-.bg-neutral-content.text-neutral
+= render 'header'
+.bg-neutral-content.text-neutral.pt-20
   .container.mx-auto
     .prose.p-10.mx-auto.text-neutral
       h1

--- a/app/views/welcome/terms_of_use.slim
+++ b/app/views/welcome/terms_of_use.slim
@@ -1,7 +1,7 @@
 - title '利用規約'
 - description 'KPI ツリーメーカー（以下、「本サービス」といいます。）をご利用いただきありがとうございます。ユーザーの皆さまには、本規約に従って、本サービスをご利用いただきます。'
-
-.bg-neutral-content.text-neutral
+= render 'header'
+.bg-neutral-content.text-neutral.pt-20
   .container.mx-auto
     .prose.p-10.mx-auto.text-neutral
       h1

--- a/spec/system/welcomes_spec.rb
+++ b/spec/system/welcomes_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe 'Welcome pages' do
     expect(page).to have_button text: 'サインアップ（無料）'
   end
 
+  it '利用規約からヘッダーロゴをクリックしてLPに戻る' do
+    visit terms_of_use_path
+    find('.ktg-logo-md').click
+    expect(page).to have_button text: 'サインアップ（無料）'
+  end
+
   it 'LPのリンクからプライバシーポリシーへ遷移する' do
     visit root_path
     click_link 'プライバシーポリシー'
@@ -30,6 +36,12 @@ RSpec.describe 'Welcome pages' do
   it 'プライバシーポリシーから「トップへ」リンクでLPに戻る' do
     visit privacy_policy_path
     click_link 'トップへ'
+    expect(page).to have_button text: 'サインアップ（無料）'
+  end
+
+  it 'プライバシーポリシーからヘッダーロゴをクリックしてLPに戻る' do
+    visit privacy_policy_path
+    find('.ktg-logo-md').click
     expect(page).to have_button text: 'サインアップ（無料）'
   end
 


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/308

close #308 

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

トップ画面に戻りやすくするため、利用規約画面、プライバシーポリシー画面、にヘッダーを表示するように変更した。

## 動作確認方法

1. ログイン前トップページのフッターから利用規約画面に遷移し、ヘッダーが表示されていること・ヘッダーロゴからトップページに遷移することを確認
1. 同じく、ログイン前トップページのフッターからプライバシーポリシー画面に遷移し、ヘッダーが表示されていること・ヘッダーロゴからトップページに遷移することを確認
1. ログイン後にツリー一覧画面のアカウントメニューから利用規約画面に遷移し、ヘッダーが表示されていること・ヘッダーロゴからツリー一覧画面に遷移することを確認
1. 同じく、ログイン後にツリー一覧画面のアカウントメニューからプライバシーポリシー画面に遷移し、ヘッダーが表示されていること・ヘッダーロゴからツリー一覧画面に遷移することを確認


<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

### 変更前

![スクリーンショット 2023-11-09 17 49 27](https://github.com/peno022/kpi-tree-generator/assets/40317050/3e1769a4-8344-4e35-a769-4a455e1a8a10)
![スクリーンショット 2023-11-09 17 49 17](https://github.com/peno022/kpi-tree-generator/assets/40317050/a54850f8-450d-45aa-984f-16817dc44c7d)
![スクリーンショット 2023-11-09 17 49 04](https://github.com/peno022/kpi-tree-generator/assets/40317050/6d62e18b-f6d8-40b7-ba27-a2288a16fd68)
![スクリーンショット 2023-11-09 17 48 52](https://github.com/peno022/kpi-tree-generator/assets/40317050/c01983d9-100e-4a95-87f9-60c80208fbd3)

### 変更後

![スクリーンショット 2023-11-09 17 48 00](https://github.com/peno022/kpi-tree-generator/assets/40317050/b2b2f892-0ffb-49db-ae52-bea2657e0220)
![スクリーンショット 2023-11-09 17 47 45](https://github.com/peno022/kpi-tree-generator/assets/40317050/ec9de9bf-e4d3-4144-8178-c0aab15a2a63)
![スクリーンショット 2023-11-09 17 48 34](https://github.com/peno022/kpi-tree-generator/assets/40317050/da53dea9-697b-444f-a379-4aea63d3d283)
![スクリーンショット 2023-11-09 17 48 20](https://github.com/peno022/kpi-tree-generator/assets/40317050/17ae232a-385c-4233-891a-1ec9ea73f9ce)

