### PR TITLE
flyioのmin_machines_runningを0→1に変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,7 @@ console_command = "/rails/bin/rails console"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
 [[statics]]


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/262

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

flyioのmin_machines_runningを0→1に変更した。

## 動作確認方法

fly.ioのDashboardから反映を確認。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛。