### PR TITLE
サイトタイトルをカタカナに変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   # rubocop:disable Metrics/MethodLength
   def default_meta_tags
     {
-      site: 'KPI TREE MAKER',
+      site: 'KPI ツリーメーカー',
       reverse: true,
       charset: 'utf-8',
       description: 'KPI ツリーメーカーは、KPI ツリーが無料で簡単につくれる Web サービスです。',
@@ -12,7 +12,7 @@ module ApplicationHelper
       og: {
         title: :title,
         type: 'website',
-        site_name: 'KPI TREE MAKER',
+        site_name: 'KPI ツリーメーカー',
         description: :description,
         image: 'https://kpi-tree.com/ogp/ogp.png',
         url: 'https://kpi-tree.com'


### PR DESCRIPTION
## Issue

なし

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

カタカナで検索される可能性のほうが高いと考え、KPI ツリーメーカー とカタカナのサイトタイトルに変更した。

## 動作確認方法

ブラウザに表示されるサイトタイトルが変更されていることを確認。

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛