### PR TITLE
APIのエラーメッセージの表示方法を修正

### DIFF
--- a/app/javascript/components/trees/tool/LayerTool.tsx
+++ b/app/javascript/components/trees/tool/LayerTool.tsx
@@ -20,6 +20,8 @@ type LayerToolProps = {
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
   treeData: TreeDataFromApi;
   onUpdateStatusChange: (isUpdating: boolean) => void;
+  handleErrorMessage: (errorMessage: string | null) => void;
+  errorMessage: string | null;
 };
 
 const LayerTool: React.FC<LayerToolProps> = ({
@@ -29,9 +31,13 @@ const LayerTool: React.FC<LayerToolProps> = ({
   onUpdateSuccess,
   treeData,
   onUpdateStatusChange,
+  handleErrorMessage,
+  errorMessage,
 }) => {
-  const { errorMessage, sendUpdateRequest, setErrorMessage, isUpdating } =
-    useTreeUpdate(treeData.tree.id);
+  const { sendUpdateRequest, isUpdating } = useTreeUpdate(
+    treeData.tree.id,
+    handleErrorMessage
+  );
 
   const {
     layerProperty,
@@ -64,7 +70,6 @@ const LayerTool: React.FC<LayerToolProps> = ({
     });
     setInputFraction(selectedLayer.fraction.toString());
     resetValidationResults(selectedNodes.length);
-    setErrorMessage(null);
   }, [selectedNodes, selectedLayer, parentNode]);
 
   useEffect(() => {

--- a/app/javascript/components/trees/tool/RootNodeTool.tsx
+++ b/app/javascript/components/trees/tool/RootNodeTool.tsx
@@ -12,6 +12,8 @@ type RootNodeToolProps = {
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
   treeData: TreeDataFromApi;
   onUpdateStatusChange: (isUpdating: boolean) => void;
+  handleErrorMessage: (errorMessage: string | null) => void;
+  errorMessage: string | null;
 };
 
 const RootNodeTool: React.FC<RootNodeToolProps> = ({
@@ -19,9 +21,13 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
   treeData,
   onUpdateSuccess,
   onUpdateStatusChange,
+  handleErrorMessage,
+  errorMessage,
 }) => {
-  const { errorMessage, sendUpdateRequest, setErrorMessage, isUpdating } =
-    useTreeUpdate(treeData.tree.id);
+  const { sendUpdateRequest, isUpdating } = useTreeUpdate(
+    treeData.tree.id,
+    handleErrorMessage
+  );
 
   const {
     nodeInfo,
@@ -40,9 +46,9 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
   );
 
   const saveNodeInfo = async () => {
-    setErrorMessage(null);
+    handleErrorMessage(null);
     if (nodeInfo.id === undefined || nodeInfo.id === null) {
-      setErrorMessage(
+      handleErrorMessage(
         "システムエラーが発生しました。画面を再読み込みしてもう一度お試しください。"
       );
       return;
@@ -69,8 +75,8 @@ const RootNodeTool: React.FC<RootNodeToolProps> = ({
 
   return (
     <>
+      {errorMessage && <AlertError message={errorMessage} />}
       <div className="relative flex flex-col h-full">
-        {errorMessage && <AlertError message={errorMessage} />}
         <div className="absolute inset-0 overflow-y-auto p-2 pb-24" id="tool">
           <NodeDetail
             index={0}

--- a/app/javascript/components/trees/tool/ToolArea.tsx
+++ b/app/javascript/components/trees/tool/ToolArea.tsx
@@ -9,6 +9,8 @@ export type ToolAreaProps = {
   selectedNodeIds: number[];
   onUpdateSuccess: (updatedTreeData: TreeDataFromApi) => void;
   onUpdateStatusChange: (isUpdating: boolean) => void;
+  handleErrorMessage: (errorMessage: string | null) => void;
+  errorMessage: string | null;
 };
 
 export const ToolArea: React.FC<ToolAreaProps> = ({
@@ -16,6 +18,8 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
   selectedNodeIds,
   onUpdateSuccess,
   onUpdateStatusChange,
+  handleErrorMessage,
+  errorMessage,
 }) => {
   const allNodes = treeData.nodes;
   const allLayers = treeData.layers;
@@ -46,6 +50,8 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
         onUpdateSuccess={onUpdateSuccess}
         treeData={treeData}
         onUpdateStatusChange={onUpdateStatusChange}
+        handleErrorMessage={handleErrorMessage}
+        errorMessage={errorMessage}
       />
     );
   }
@@ -65,6 +71,8 @@ export const ToolArea: React.FC<ToolAreaProps> = ({
         onUpdateSuccess={onUpdateSuccess}
         treeData={treeData}
         onUpdateStatusChange={onUpdateStatusChange}
+        handleErrorMessage={handleErrorMessage}
+        errorMessage={errorMessage}
       ></LayerTool>
     );
   }

--- a/app/javascript/components/trees/tree/TreeArea.tsx
+++ b/app/javascript/components/trees/tree/TreeArea.tsx
@@ -34,8 +34,14 @@ export const TreeArea: React.FC<TreeAreaProps> = ({
   onUpdateSuccess,
   onUpdateStatusChange,
 }) => {
-  const { errorMessage, sendUpdateRequest, setErrorMessage, isUpdating } =
-    useTreeUpdate(treeData.tree.id);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const handleErrorMessage = (message: string | null) => {
+    setErrorMessage(message);
+  };
+  const { sendUpdateRequest, isUpdating } = useTreeUpdate(
+    treeData.tree.id,
+    handleErrorMessage
+  );
   const [hoveredNodeId, setHoveredNodeId] = useState<number | null>(null);
 
   useEffect(() => {
@@ -74,7 +80,6 @@ export const TreeArea: React.FC<TreeAreaProps> = ({
     };
     const result = await sendUpdateRequest(newTreeData);
     if (result) {
-      console.dir(result);
       const newNodeIds = result.nodes
         .filter((node) => node.parentId === parentNodeId)
         .map((node) => node.id);

--- a/app/javascript/hooks/useTreeUpdate.ts
+++ b/app/javascript/hooks/useTreeUpdate.ts
@@ -6,18 +6,18 @@ import nullifyParentNodeId from "@/nullifyParentNodeId";
 import token from "@/token";
 
 export type TreeUpdateHook = {
-  errorMessage: string | null;
   sendUpdateRequest: (treeData: TreeData) => Promise<TreeDataFromApi | null>;
-  setErrorMessage: React.Dispatch<React.SetStateAction<string | null>>;
   isUpdating: boolean;
 };
 
-export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+export const useTreeUpdate = (
+  treeId: number,
+  handleErrorMessage: (errorMessage: string | null) => void
+): TreeUpdateHook => {
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
 
   const sendUpdateRequest = async (treeData: TreeData) => {
-    setErrorMessage(null);
+    handleErrorMessage(null);
     setIsUpdating(true);
     const treeDataToSave = nullifyParentNodeId(treeData);
     const bodyData = JSON.stringify(
@@ -39,11 +39,11 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
       if (response.status === 422) {
         const json = await response.json();
         setIsUpdating(false);
-        setErrorMessage(json.errors.join("／"));
+        handleErrorMessage(json.errors.join("／"));
         return null;
       } else if (response.status >= 500) {
         setIsUpdating(false);
-        setErrorMessage(
+        handleErrorMessage(
           "システムエラーが発生しました。時間を置いてもう一度お試しください。"
         );
         return null;
@@ -53,7 +53,7 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
         return null;
       } else {
         setIsUpdating(false);
-        setErrorMessage(
+        handleErrorMessage(
           "システムエラーが発生しました。時間を置いてもう一度お試しください。"
         );
         return null;
@@ -65,9 +65,7 @@ export const useTreeUpdate = (treeId: number): TreeUpdateHook => {
   };
 
   return {
-    errorMessage,
     sendUpdateRequest,
-    setErrorMessage,
     isUpdating,
   };
 };

--- a/app/javascript/pages/trees/edit.tsx
+++ b/app/javascript/pages/trees/edit.tsx
@@ -21,6 +21,9 @@ const EditTreePage = () => {
   const [isLoading, setisLoading] = useState(true);
   const [isUpdating, setIsUpdating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [updateErrorMessage, setUpdateErrorMessage] = useState<string | null>(
+    null
+  );
 
   const getTreeSize = () => {
     const svgElement = document.querySelector("#treeWrapper svg");
@@ -99,6 +102,7 @@ const EditTreePage = () => {
     const clickedNode = treeData.nodes.find(
       (node) => node.id === clickedNodeId
     );
+    handleUpdateErrorMessage(null);
     if (!clickedNode) {
       setErrorMessage(
         "エラーが発生しています。画面を再読み込みしてもう一度お試しください。"
@@ -119,6 +123,11 @@ const EditTreePage = () => {
   ) => {
     setTreeData(updatedTreeData);
     setSelectedNodeIds(selectedNodeIds);
+    setUpdateErrorMessage(null);
+  };
+
+  const handleUpdateErrorMessage = (errorMessage: string | null) => {
+    setUpdateErrorMessage(errorMessage);
   };
 
   const isLargeScreen = window.innerWidth >= 1024;
@@ -166,6 +175,8 @@ const EditTreePage = () => {
               selectedNodeIds={selectedNodeIds}
               onUpdateSuccess={handleUpdateSuccess}
               onUpdateStatusChange={(status: boolean) => setIsUpdating(status)}
+              handleErrorMessage={handleUpdateErrorMessage}
+              errorMessage={updateErrorMessage}
             />
           </ErrorBoundary>
         </div>

--- a/spec/javascript/components/trees/tool/ToolArea.spec.tsx
+++ b/spec/javascript/components/trees/tool/ToolArea.spec.tsx
@@ -55,6 +55,8 @@ describe("ノードが選択されていないとき", () => {
       selectedNodeIds: [],
       onUpdateSuccess: jest.fn(),
       onUpdateStatusChange: jest.fn(),
+      handleErrorMessage: jest.fn(),
+      errorMessage: null,
     };
     render(<ToolArea {...toolAreaProps} />);
     expect(
@@ -71,6 +73,8 @@ describe("正常なデータでは起きないはずのエラー", () => {
         selectedNodeIds: [999999, 9999999],
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(
@@ -92,6 +96,8 @@ describe("正常なデータでは起きないはずのエラー", () => {
         selectedNodeIds: [2, 3],
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(screen.getByText("存在しない階層です。")).toBeInTheDocument();
@@ -107,6 +113,8 @@ describe("選択したノードが子ノードのとき", () => {
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
 
@@ -128,6 +136,8 @@ describe("選択したノードが子ノードのとき", () => {
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       const { container } = render(<ToolArea {...toolAreaProps} />);
       const calculationDiv = container.querySelector(".calculation");
@@ -152,6 +162,8 @@ describe("選択したノードが子ノードのとき", () => {
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
       expect(getNodeField(1, "名前")).toHaveValue("子ノード1");
@@ -172,6 +184,8 @@ describe("選択したノードが子ノードのとき", () => {
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
 
@@ -186,6 +200,8 @@ describe("選択したノードが子ノードのとき", () => {
         selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
       const updateButton = getUpdateButton();
@@ -203,6 +219,8 @@ describe("入力値のバリデーション", () => {
       selectedNodeIds: [2, 3], // 子ノード1と子ノード2を選択
       onUpdateSuccess: jest.fn(),
       onUpdateStatusChange: jest.fn(),
+      handleErrorMessage: jest.fn(),
+      errorMessage: null,
     };
     render(<ToolArea {...toolAreaProps} />);
   });
@@ -611,6 +629,8 @@ describe("選択したノードがルートノードの時", () => {
         selectedNodeIds: [1],
         onUpdateSuccess: jest.fn(),
         onUpdateStatusChange: jest.fn(),
+        handleErrorMessage: jest.fn(),
+        errorMessage: null,
       };
       render(<ToolArea {...toolAreaProps} />);
     });


### PR DESCRIPTION
## Issue

- https://github.com/peno022/kpi-tree-generator/issues/318

<!--
- https://github.com/peno022/kpi-tree-generator/issues/xxx
-->

## 概要

- ツリー更新APIのレスポンスがエラーだった場合に、エラーメッセージをReactコンポーネントに正しく表示できていなかったので修正。
  - エラーメッセージをstatusにセット後、isUpdating の値が変更されると即座にコンポーネントが再描画されてエラーメッセージが初期化されてしまっていた。
  - state のリフトアップを行い、エラーメッセージの管理を Edit に持たせるように変更。

## 動作確認方法

- 一時的にAPIがエラーを返す状態にする
- 任意のツリーの編集画面を開き、任意のノードをクリックしてツールエリアから更新を実行
- エラーメッセージが画面に表示されることを確認する
- 他の階層を開くとエラーメッセージが消えることを確認する

<!--
例:
1. {branch_name}をローカルに取り込む
2. 
-->

## Screenshot

割愛
